### PR TITLE
Add custom field display and editing (#8)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 GitHub Projects V2 をターミナル上でカンバンボード形式で操作する `gh` CLI 拡張。
 
+## 作業ディレクトリ
+
+worktree (`.claude/worktrees/<name>/`) 配下で起動された場合は、その worktree 内でのみ作業する。`cd` でリポジトリルートや他の worktree に移動しない。ビルド・テスト・コミット・PR 作成はすべて現在の worktree から行う。
+
 ## 技術スタック
 
 - Rust (edition 2024)

--- a/src/app.rs
+++ b/src/app.rs
@@ -328,6 +328,39 @@ impl App {
             Command::OpenUrl(url) => {
                 let _ = open::that(&url);
             }
+            Command::UpdateCustomField {
+                project_id,
+                item_id,
+                field_id,
+                value,
+            } => {
+                let client = self.github.clone();
+                let tx = self.event_tx.clone();
+                tokio::spawn(async move {
+                    let result = client
+                        .update_custom_field(&project_id, &item_id, &field_id, &value)
+                        .await;
+                    let _ = tx.send(AppEvent::CustomFieldUpdated(
+                        result.map_err(|e| e.to_string()),
+                    ));
+                });
+            }
+            Command::ClearCustomField {
+                project_id,
+                item_id,
+                field_id,
+            } => {
+                let client = self.github.clone();
+                let tx = self.event_tx.clone();
+                tokio::spawn(async move {
+                    let result = client
+                        .clear_custom_field(&project_id, &item_id, &field_id)
+                        .await;
+                    let _ = tx.send(AppEvent::CustomFieldUpdated(
+                        result.map_err(|e| e.to_string()),
+                    ));
+                });
+            }
             Command::Batch(cmds) => {
                 for cmd in cmds {
                     self.execute(cmd);

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -5,12 +5,41 @@ use crate::command::Command;
 use crate::config::ViewConfig;
 use crate::event::AppEvent;
 use crate::keymap::{Keymap, KeymapMode};
-use crate::model::project::{Board, Card, CardType, ProjectSummary};
+use crate::command::CustomFieldValueInput;
+use crate::model::project::{
+    Board, Card, CardType, CustomFieldValue, FieldDefinition, ProjectSummary,
+};
+
+fn format_number(n: f64) -> String {
+    if n.fract() == 0.0 && n.abs() < 1e16 {
+        format!("{}", n as i64)
+    } else {
+        format!("{n}")
+    }
+}
+
+fn is_valid_iso_date(s: &str) -> bool {
+    // YYYY-MM-DD 形式のみ許容 (簡易バリデーション)
+    let bytes = s.as_bytes();
+    if bytes.len() != 10 {
+        return false;
+    }
+    if bytes[4] != b'-' || bytes[7] != b'-' {
+        return false;
+    }
+    let all_digits = |slice: &[u8]| slice.iter().all(|b| b.is_ascii_digit());
+    if !all_digits(&bytes[0..4]) || !all_digits(&bytes[5..7]) || !all_digits(&bytes[8..10]) {
+        return false;
+    }
+    let month: u32 = s[5..7].parse().unwrap_or(0);
+    let day: u32 = s[8..10].parse().unwrap_or(0);
+    (1..=12).contains(&month) && (1..=31).contains(&day)
+}
 use crate::model::state::{
     ActiveFilter, CommentListState, ConfirmAction, ConfirmState, CreateCardField,
     CreateCardState, DetailPane, EditCardField, EditCardState, EditItem, FilterState, GrabState,
     LoadingState, NewCardType, PendingIssueCreate, RepoSelectState, SidebarEditMode, ViewMode,
-    SIDEBAR_ASSIGNEES, SIDEBAR_DELETE, SIDEBAR_LABELS, SIDEBAR_SECTION_COUNT, SIDEBAR_STATUS,
+    SIDEBAR_ASSIGNEES, SIDEBAR_LABELS, SIDEBAR_STATUS,
 };
 
 pub struct AppState {
@@ -385,6 +414,19 @@ impl AppState {
             AppEvent::CommentsLoaded(Err(e)) => {
                 self.loading = LoadingState::Error(e);
                 Command::None
+            }
+            AppEvent::CustomFieldUpdated(Ok(())) => {
+                // 楽観的更新済み
+                Command::None
+            }
+            AppEvent::CustomFieldUpdated(Err(e)) => {
+                self.loading = LoadingState::Error(e);
+                if let Some(project) = &self.current_project {
+                    let id = project.id.clone();
+                    self.start_loading_board(&id)
+                } else {
+                    Command::None
+                }
             }
             AppEvent::Tick | AppEvent::Resize(_, _) => Command::None,
         }
@@ -1747,37 +1789,169 @@ impl AppState {
         }
     }
 
+    /// サイドバーの総セクション数 (Status/Assignees/Labels/Milestone + custom_fields + Delete)
+    pub fn sidebar_section_count(&self) -> usize {
+        4 + self.field_definitions().len() + 1
+    }
+
+    /// Delete セクションのインデックス (動的)
+    pub fn sidebar_delete_index(&self) -> usize {
+        4 + self.field_definitions().len()
+    }
+
+    /// サイドバーインデックスが カスタムフィールド行なら、対応する FieldDefinition の index を返す
+    pub fn sidebar_field_index(&self, sidebar_index: usize) -> Option<usize> {
+        if sidebar_index >= 4 && sidebar_index < self.sidebar_delete_index() {
+            Some(sidebar_index - 4)
+        } else {
+            None
+        }
+    }
+
+    fn field_definitions(&self) -> &[FieldDefinition] {
+        self.board
+            .as_ref()
+            .map(|b| b.field_definitions.as_slice())
+            .unwrap_or(&[])
+    }
+
     fn handle_detail_sidebar_action(&mut self, action: Action) -> Command {
         match action {
             Action::MoveDown => {
-                self.sidebar_selected =
-                    (self.sidebar_selected + 1).min(SIDEBAR_SECTION_COUNT - 1);
+                let max = self.sidebar_section_count().saturating_sub(1);
+                self.sidebar_selected = (self.sidebar_selected + 1).min(max);
                 Command::None
             }
             Action::MoveUp => {
                 self.sidebar_selected = self.sidebar_selected.saturating_sub(1);
                 Command::None
             }
-            Action::Select => match self.sidebar_selected {
-                SIDEBAR_STATUS => {
-                    self.status_select_open = true;
-                    self.status_select_cursor = self.selected_column;
-                    Command::None
+            Action::Select => {
+                let idx = self.sidebar_selected;
+                let delete_idx = self.sidebar_delete_index();
+                match idx {
+                    SIDEBAR_STATUS => {
+                        self.status_select_open = true;
+                        self.status_select_cursor = self.selected_column;
+                        Command::None
+                    }
+                    SIDEBAR_LABELS => self.open_label_edit(),
+                    SIDEBAR_ASSIGNEES => self.open_assignee_edit(),
+                    i if i == delete_idx => {
+                        self.start_delete_card(ViewMode::Detail);
+                        Command::None
+                    }
+                    _ => {
+                        if let Some(field_idx) = self.sidebar_field_index(idx) {
+                            self.open_custom_field_edit(field_idx);
+                        }
+                        Command::None
+                    }
                 }
-                SIDEBAR_LABELS => self.open_label_edit(),
-                SIDEBAR_ASSIGNEES => self.open_assignee_edit(),
-                SIDEBAR_DELETE => {
-                    self.start_delete_card(ViewMode::Detail);
-                    Command::None
-                }
-                _ => Command::None,
-            },
+            }
             Action::DeleteCard => {
                 self.start_delete_card(ViewMode::Detail);
                 Command::None
             }
             _ => Command::None,
         }
+    }
+
+    fn open_custom_field_edit(&mut self, field_idx: usize) {
+        let (field, current_value) = {
+            let Some(board) = self.board.as_ref() else {
+                return;
+            };
+            let Some(field) = board.field_definitions.get(field_idx).cloned() else {
+                return;
+            };
+            let current = self
+                .selected_card_ref()
+                .and_then(|c| {
+                    c.custom_fields
+                        .iter()
+                        .find(|v| v.field_id() == field.id())
+                        .cloned()
+                });
+            (field, current)
+        };
+
+        let edit = match &field {
+            FieldDefinition::SingleSelect { id, name, options } => {
+                let current_option_id = match &current_value {
+                    Some(CustomFieldValue::SingleSelect { option_id, .. }) => Some(option_id),
+                    _ => None,
+                };
+                let cursor = current_option_id
+                    .and_then(|oid| options.iter().position(|o| &o.id == oid))
+                    .unwrap_or(0);
+                SidebarEditMode::CustomFieldSingleSelect {
+                    field_id: id.clone(),
+                    field_name: name.clone(),
+                    options: options.clone(),
+                    cursor,
+                }
+            }
+            FieldDefinition::Iteration {
+                id,
+                name,
+                iterations,
+            } => {
+                let current_iteration_id = match &current_value {
+                    Some(CustomFieldValue::Iteration { iteration_id, .. }) => Some(iteration_id),
+                    _ => None,
+                };
+                let cursor = current_iteration_id
+                    .and_then(|iid| iterations.iter().position(|it| &it.id == iid))
+                    .unwrap_or(0);
+                SidebarEditMode::CustomFieldIteration {
+                    field_id: id.clone(),
+                    field_name: name.clone(),
+                    iterations: iterations.clone(),
+                    cursor,
+                }
+            }
+            FieldDefinition::Text { id, name } => {
+                let input = match &current_value {
+                    Some(CustomFieldValue::Text { text, .. }) => text.clone(),
+                    _ => String::new(),
+                };
+                let cursor_pos = input.chars().count();
+                SidebarEditMode::CustomFieldText {
+                    field_id: id.clone(),
+                    field_name: name.clone(),
+                    input,
+                    cursor_pos,
+                }
+            }
+            FieldDefinition::Number { id, name } => {
+                let input = match &current_value {
+                    Some(CustomFieldValue::Number { number, .. }) => format_number(*number),
+                    _ => String::new(),
+                };
+                let cursor_pos = input.chars().count();
+                SidebarEditMode::CustomFieldNumber {
+                    field_id: id.clone(),
+                    field_name: name.clone(),
+                    input,
+                    cursor_pos,
+                }
+            }
+            FieldDefinition::Date { id, name } => {
+                let input = match &current_value {
+                    Some(CustomFieldValue::Date { date, .. }) => date.clone(),
+                    _ => String::new(),
+                };
+                let cursor_pos = input.chars().count();
+                SidebarEditMode::CustomFieldDate {
+                    field_id: id.clone(),
+                    field_name: name.clone(),
+                    input,
+                    cursor_pos,
+                }
+            }
+        };
+        self.sidebar_edit = Some(edit);
     }
 
     fn handle_comment_list_key(&mut self, key: KeyEvent) -> Command {
@@ -1957,6 +2131,16 @@ impl AppState {
     }
 
     fn handle_sidebar_edit_key(&mut self, key: KeyEvent) -> Command {
+        // テキスト入力系は SidebarEdit のキーマップを通さず直接処理
+        if matches!(
+            self.sidebar_edit,
+            Some(SidebarEditMode::CustomFieldText { .. })
+                | Some(SidebarEditMode::CustomFieldNumber { .. })
+                | Some(SidebarEditMode::CustomFieldDate { .. })
+        ) {
+            return self.handle_custom_field_text_key(key);
+        }
+
         let action = match self.keymap.resolve(KeymapMode::SidebarEdit, &key) {
             Some(a) => a,
             None => return Command::None,
@@ -1970,6 +2154,15 @@ impl AppState {
         let (items_len, cursor) = match edit {
             SidebarEditMode::Labels { items, cursor } => (items.len(), cursor),
             SidebarEditMode::Assignees { items, cursor } => (items.len(), cursor),
+            SidebarEditMode::CustomFieldSingleSelect { options, cursor, .. } => {
+                (options.len() + 1, cursor) // +1 は "None" (クリア)
+            }
+            SidebarEditMode::CustomFieldIteration { iterations, cursor, .. } => {
+                (iterations.len() + 1, cursor)
+            }
+            SidebarEditMode::CustomFieldText { .. }
+            | SidebarEditMode::CustomFieldNumber { .. }
+            | SidebarEditMode::CustomFieldDate { .. } => unreachable!("dispatched above"),
         };
 
         match action {
@@ -2072,6 +2265,321 @@ impl AppState {
                 }
                 Command::None
             }
+            SidebarEditMode::CustomFieldSingleSelect { .. }
+            | SidebarEditMode::CustomFieldIteration { .. } => {
+                self.commit_custom_field_selection()
+            }
+            SidebarEditMode::CustomFieldText { .. }
+            | SidebarEditMode::CustomFieldNumber { .. }
+            | SidebarEditMode::CustomFieldDate { .. } => Command::None,
+        }
+    }
+
+    fn commit_custom_field_selection(&mut self) -> Command {
+        let project_id = match self.current_project.as_ref() {
+            Some(p) => p.id.clone(),
+            None => return Command::None,
+        };
+        let item_id = match self.selected_card_ref() {
+            Some(c) => c.item_id.clone(),
+            None => return Command::None,
+        };
+
+        // 編集モードを取り出してクローズ
+        let edit = self.sidebar_edit.take();
+        let (field_id, cmd, updated_value): (String, Command, Option<CustomFieldValue>) = match edit
+        {
+            Some(SidebarEditMode::CustomFieldSingleSelect {
+                field_id,
+                options,
+                cursor,
+                ..
+            }) => {
+                if cursor >= options.len() {
+                    // None (クリア)
+                    (
+                        field_id.clone(),
+                        Command::ClearCustomField {
+                            project_id,
+                            item_id,
+                            field_id,
+                        },
+                        None,
+                    )
+                } else {
+                    let opt = &options[cursor];
+                    let new_val = CustomFieldValue::SingleSelect {
+                        field_id: field_id.clone(),
+                        option_id: opt.id.clone(),
+                        name: opt.name.clone(),
+                        color: opt.color.clone(),
+                    };
+                    (
+                        field_id.clone(),
+                        Command::UpdateCustomField {
+                            project_id,
+                            item_id,
+                            field_id,
+                            value: CustomFieldValueInput::SingleSelect {
+                                option_id: opt.id.clone(),
+                            },
+                        },
+                        Some(new_val),
+                    )
+                }
+            }
+            Some(SidebarEditMode::CustomFieldIteration {
+                field_id,
+                iterations,
+                cursor,
+                ..
+            }) => {
+                if cursor >= iterations.len() {
+                    (
+                        field_id.clone(),
+                        Command::ClearCustomField {
+                            project_id,
+                            item_id,
+                            field_id,
+                        },
+                        None,
+                    )
+                } else {
+                    let it = &iterations[cursor];
+                    let new_val = CustomFieldValue::Iteration {
+                        field_id: field_id.clone(),
+                        iteration_id: it.id.clone(),
+                        title: it.title.clone(),
+                    };
+                    (
+                        field_id.clone(),
+                        Command::UpdateCustomField {
+                            project_id,
+                            item_id,
+                            field_id,
+                            value: CustomFieldValueInput::Iteration {
+                                iteration_id: it.id.clone(),
+                            },
+                        },
+                        Some(new_val),
+                    )
+                }
+            }
+            other => {
+                // 想定外: 復元
+                self.sidebar_edit = other;
+                return Command::None;
+            }
+        };
+
+        self.apply_custom_field_optimistic(&field_id, updated_value);
+        cmd
+    }
+
+    fn apply_custom_field_optimistic(
+        &mut self,
+        field_id: &str,
+        new_value: Option<CustomFieldValue>,
+    ) {
+        let Some(real_idx) = self.real_card_index() else {
+            return;
+        };
+        let Some(board) = self.board.as_mut() else {
+            return;
+        };
+        let Some(col) = board.columns.get_mut(self.selected_column) else {
+            return;
+        };
+        let Some(card) = col.cards.get_mut(real_idx) else {
+            return;
+        };
+        card.custom_fields.retain(|v| v.field_id() != field_id);
+        if let Some(v) = new_value {
+            card.custom_fields.push(v);
+        }
+    }
+
+    fn handle_custom_field_text_key(&mut self, key: KeyEvent) -> Command {
+        // キーマップは使わず直接 KeyCode を解釈 (Space が ToggleItem に奪われないため)
+        match key.code {
+            KeyCode::Esc => {
+                self.sidebar_edit = None;
+                return Command::None;
+            }
+            KeyCode::Enter => return self.commit_custom_field_text(),
+            _ => {}
+        }
+
+        let edit = match &mut self.sidebar_edit {
+            Some(e) => e,
+            None => return Command::None,
+        };
+        let (input, cursor_pos): (&mut String, &mut usize) = match edit {
+            SidebarEditMode::CustomFieldText {
+                input, cursor_pos, ..
+            }
+            | SidebarEditMode::CustomFieldNumber {
+                input, cursor_pos, ..
+            }
+            | SidebarEditMode::CustomFieldDate {
+                input, cursor_pos, ..
+            } => (input, cursor_pos),
+            _ => return Command::None,
+        };
+
+        match key.code {
+            KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+                let byte = input
+                    .char_indices()
+                    .nth(*cursor_pos)
+                    .map(|(i, _)| i)
+                    .unwrap_or(input.len());
+                input.insert(byte, c);
+                *cursor_pos += 1;
+            }
+            KeyCode::Backspace => {
+                if *cursor_pos > 0 {
+                    let prev_byte = input
+                        .char_indices()
+                        .nth(*cursor_pos - 1)
+                        .map(|(i, _)| i)
+                        .unwrap_or(0);
+                    let cur_byte = input
+                        .char_indices()
+                        .nth(*cursor_pos)
+                        .map(|(i, _)| i)
+                        .unwrap_or(input.len());
+                    input.drain(prev_byte..cur_byte);
+                    *cursor_pos -= 1;
+                }
+            }
+            KeyCode::Left => {
+                *cursor_pos = cursor_pos.saturating_sub(1);
+            }
+            KeyCode::Right => {
+                let max = input.chars().count();
+                *cursor_pos = (*cursor_pos + 1).min(max);
+            }
+            _ => {}
+        }
+        Command::None
+    }
+
+    fn commit_custom_field_text(&mut self) -> Command {
+        let project_id = match self.current_project.as_ref() {
+            Some(p) => p.id.clone(),
+            None => return Command::None,
+        };
+        let item_id = match self.selected_card_ref() {
+            Some(c) => c.item_id.clone(),
+            None => return Command::None,
+        };
+        let edit = self.sidebar_edit.take();
+        match edit {
+            Some(SidebarEditMode::CustomFieldText {
+                field_id, input, ..
+            }) => {
+                if input.is_empty() {
+                    self.apply_custom_field_optimistic(&field_id, None);
+                    Command::ClearCustomField {
+                        project_id,
+                        item_id,
+                        field_id,
+                    }
+                } else {
+                    let new_val = CustomFieldValue::Text {
+                        field_id: field_id.clone(),
+                        text: input.clone(),
+                    };
+                    self.apply_custom_field_optimistic(&field_id, Some(new_val));
+                    Command::UpdateCustomField {
+                        project_id,
+                        item_id,
+                        field_id,
+                        value: CustomFieldValueInput::Text { text: input },
+                    }
+                }
+            }
+            Some(SidebarEditMode::CustomFieldNumber {
+                field_id,
+                field_name,
+                input,
+                cursor_pos,
+            }) => {
+                if input.is_empty() {
+                    self.apply_custom_field_optimistic(&field_id, None);
+                    return Command::ClearCustomField {
+                        project_id,
+                        item_id,
+                        field_id,
+                    };
+                }
+                match input.trim().parse::<f64>() {
+                    Ok(n) if n.is_finite() => {
+                        let new_val = CustomFieldValue::Number {
+                            field_id: field_id.clone(),
+                            number: n,
+                        };
+                        self.apply_custom_field_optimistic(&field_id, Some(new_val));
+                        Command::UpdateCustomField {
+                            project_id,
+                            item_id,
+                            field_id,
+                            value: CustomFieldValueInput::Number { number: n },
+                        }
+                    }
+                    _ => {
+                        // バリデーション失敗: 復元
+                        self.sidebar_edit = Some(SidebarEditMode::CustomFieldNumber {
+                            field_id,
+                            field_name,
+                            input,
+                            cursor_pos,
+                        });
+                        Command::None
+                    }
+                }
+            }
+            Some(SidebarEditMode::CustomFieldDate {
+                field_id,
+                field_name,
+                input,
+                cursor_pos,
+            }) => {
+                if input.is_empty() {
+                    self.apply_custom_field_optimistic(&field_id, None);
+                    return Command::ClearCustomField {
+                        project_id,
+                        item_id,
+                        field_id,
+                    };
+                }
+                if is_valid_iso_date(&input) {
+                    let new_val = CustomFieldValue::Date {
+                        field_id: field_id.clone(),
+                        date: input.clone(),
+                    };
+                    self.apply_custom_field_optimistic(&field_id, Some(new_val));
+                    Command::UpdateCustomField {
+                        project_id,
+                        item_id,
+                        field_id,
+                        value: CustomFieldValueInput::Date { date: input },
+                    }
+                } else {
+                    self.sidebar_edit = Some(SidebarEditMode::CustomFieldDate {
+                        field_id,
+                        field_name,
+                        input,
+                        cursor_pos,
+                    });
+                    Command::None
+                }
+            }
+            other => {
+                self.sidebar_edit = other;
+                Command::None
+            }
         }
     }
 
@@ -2133,6 +2641,7 @@ pub fn next_char_pos(s: &str, pos: usize) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::command::CustomFieldValueInput;
     use crate::model::project::*;
     use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
 
@@ -2167,6 +2676,7 @@ mod tests {
             body: None,
             comments: vec![],
             milestone: None,
+            custom_fields: vec![],
         }
     }
 
@@ -2190,6 +2700,7 @@ mod tests {
             body: None,
             comments: vec![],
             milestone: None,
+            custom_fields: vec![],
         }
     }
 
@@ -2206,6 +2717,7 @@ mod tests {
             body: None,
             comments: vec![],
             milestone: None,
+            custom_fields: vec![],
         }
     }
 
@@ -2222,6 +2734,28 @@ mod tests {
             body: None,
             comments: vec![],
             milestone: Some(milestone.into()),
+            custom_fields: vec![],
+        }
+    }
+
+    fn make_card_with_custom_fields(
+        item_id: &str,
+        title: &str,
+        custom_fields: Vec<CustomFieldValue>,
+    ) -> Card {
+        Card {
+            item_id: item_id.into(),
+            content_id: Some(format!("content_{item_id}")),
+            title: title.into(),
+            number: None,
+            card_type: CardType::DraftIssue,
+            assignees: vec![],
+            labels: vec![],
+            url: None,
+            body: None,
+            comments: vec![],
+            milestone: None,
+            custom_fields,
         }
     }
 
@@ -2239,7 +2773,17 @@ mod tests {
                 })
                 .collect(),
             repositories: vec![],
+            field_definitions: vec![],
         }
+    }
+
+    fn make_board_with_fields(
+        columns: Vec<(&str, &str, Vec<Card>)>,
+        field_definitions: Vec<FieldDefinition>,
+    ) -> Board {
+        let mut board = make_board(columns);
+        board.field_definitions = field_definitions;
+        board
     }
 
     fn make_board_with_repos(
@@ -4057,7 +4601,7 @@ mod tests {
         state.selected_card = 0;
         state.mode = ViewMode::Detail;
         state.detail_pane = DetailPane::Sidebar;
-        state.sidebar_selected = SIDEBAR_DELETE;
+        state.sidebar_selected = state.sidebar_delete_index();
 
         let cmd = state.handle_event(AppEvent::Key(key(KeyCode::Enter)));
         assert_eq!(state.mode, ViewMode::Confirm);
@@ -4157,6 +4701,7 @@ mod tests {
             body: None,
             comments: vec![],
             milestone: None,
+            custom_fields: vec![],
         }
     }
 
@@ -4316,6 +4861,7 @@ mod tests {
             body: Some(body.into()),
             comments: vec![],
             milestone: None,
+            custom_fields: vec![],
         }
     }
 
@@ -4595,6 +5141,7 @@ mod tests {
             body: Some("body".into()),
             comments,
             milestone: None,
+            custom_fields: vec![],
         }
     }
 
@@ -5318,5 +5865,394 @@ mod tests {
         state.handle_event(AppEvent::Key(key(KeyCode::Enter)));
 
         assert_eq!(state.filtered_card_indices(0), vec![0]);
+    }
+
+    // ========== カスタムフィールド (Issue #8) ==========
+
+    fn priority_field() -> FieldDefinition {
+        FieldDefinition::SingleSelect {
+            id: "fld_priority".into(),
+            name: "Priority".into(),
+            options: vec![
+                SingleSelectOption {
+                    id: "opt_p0".into(),
+                    name: "P0".into(),
+                    color: Some(ColumnColor::Red),
+                },
+                SingleSelectOption {
+                    id: "opt_p1".into(),
+                    name: "P1".into(),
+                    color: Some(ColumnColor::Orange),
+                },
+                SingleSelectOption {
+                    id: "opt_p2".into(),
+                    name: "P2".into(),
+                    color: Some(ColumnColor::Gray),
+                },
+            ],
+        }
+    }
+
+    fn estimate_field() -> FieldDefinition {
+        FieldDefinition::Number {
+            id: "fld_estimate".into(),
+            name: "Estimate".into(),
+        }
+    }
+
+    fn notes_field() -> FieldDefinition {
+        FieldDefinition::Text {
+            id: "fld_notes".into(),
+            name: "Notes".into(),
+        }
+    }
+
+    fn due_field() -> FieldDefinition {
+        FieldDefinition::Date {
+            id: "fld_due".into(),
+            name: "Due".into(),
+        }
+    }
+
+    fn sprint_field() -> FieldDefinition {
+        FieldDefinition::Iteration {
+            id: "fld_sprint".into(),
+            name: "Sprint".into(),
+            iterations: vec![
+                IterationOption {
+                    id: "it_1".into(),
+                    title: "Sprint 1".into(),
+                    start_date: "2026-04-01".into(),
+                },
+                IterationOption {
+                    id: "it_2".into(),
+                    title: "Sprint 2".into(),
+                    start_date: "2026-04-15".into(),
+                },
+            ],
+        }
+    }
+
+    fn setup_detail_with_fields(
+        card: Card,
+        fields: Vec<FieldDefinition>,
+    ) -> AppState {
+        let board = make_board_with_fields(
+            vec![("Todo", "opt_1", vec![card])],
+            fields,
+        );
+        let mut state = make_state_with_board(board);
+        state.selected_column = 0;
+        state.selected_card = 0;
+        state.mode = ViewMode::Detail;
+        state.detail_pane = DetailPane::Sidebar;
+        state
+    }
+
+    #[test]
+    fn test_sidebar_navigation_extends_with_custom_fields() {
+        let card = make_card_with_custom_fields("1", "Card A", vec![]);
+        let mut state = setup_detail_with_fields(
+            card,
+            vec![priority_field(), estimate_field()],
+        );
+
+        // Status (0) → Assignees (1) → Labels (2) → Milestone (3) → Priority (4) → Estimate (5) → Delete (6)
+        state.sidebar_selected = 3; // Milestone
+        state.handle_event(AppEvent::Key(key(KeyCode::Char('j'))));
+        assert_eq!(state.sidebar_selected, 4); // Priority
+        state.handle_event(AppEvent::Key(key(KeyCode::Char('j'))));
+        assert_eq!(state.sidebar_selected, 5); // Estimate
+        state.handle_event(AppEvent::Key(key(KeyCode::Char('j'))));
+        assert_eq!(state.sidebar_selected, 6); // Delete
+        state.handle_event(AppEvent::Key(key(KeyCode::Char('j'))));
+        assert_eq!(state.sidebar_selected, 6); // clamp
+    }
+
+    #[test]
+    fn test_enter_on_single_select_opens_edit_mode() {
+        let card = make_card_with_custom_fields(
+            "1",
+            "Card A",
+            vec![CustomFieldValue::SingleSelect {
+                field_id: "fld_priority".into(),
+                option_id: "opt_p1".into(),
+                name: "P1".into(),
+                color: Some(ColumnColor::Orange),
+            }],
+        );
+        let mut state = setup_detail_with_fields(card, vec![priority_field()]);
+        state.sidebar_selected = 4; // Priority
+
+        let cmd = state.handle_event(AppEvent::Key(key(KeyCode::Enter)));
+        assert_eq!(cmd, Command::None);
+        match &state.sidebar_edit {
+            Some(SidebarEditMode::CustomFieldSingleSelect {
+                field_id,
+                options,
+                cursor,
+                ..
+            }) => {
+                assert_eq!(field_id, "fld_priority");
+                assert_eq!(options.len(), 3);
+                // 現在の値 (P1) の行にカーソルがある
+                assert_eq!(*cursor, 1);
+            }
+            _ => panic!("expected CustomFieldSingleSelect, got {:?}", state.sidebar_edit),
+        }
+    }
+
+    #[test]
+    fn test_single_select_toggle_sets_value_and_returns_update_command() {
+        let card = make_card_with_custom_fields("1", "Card A", vec![]);
+        let mut state = setup_detail_with_fields(card, vec![priority_field()]);
+        state.sidebar_selected = 4;
+        state.handle_event(AppEvent::Key(key(KeyCode::Enter))); // open
+
+        // P0 を選択 (cursor 0 → Enter)
+        let cmd = state.handle_event(AppEvent::Key(key(KeyCode::Enter)));
+        match cmd {
+            Command::UpdateCustomField {
+                field_id,
+                value: CustomFieldValueInput::SingleSelect { option_id },
+                ..
+            } => {
+                assert_eq!(field_id, "fld_priority");
+                assert_eq!(option_id, "opt_p0");
+            }
+            other => panic!("expected UpdateCustomField, got {other:?}"),
+        }
+
+        // 楽観的更新: card.custom_fields に SingleSelect { option_id: opt_p0 } が入っている
+        let card = state.selected_card_ref().unwrap();
+        let v = card.custom_fields.iter().find(|v| v.field_id() == "fld_priority");
+        match v {
+            Some(CustomFieldValue::SingleSelect { option_id, name, .. }) => {
+                assert_eq!(option_id, "opt_p0");
+                assert_eq!(name, "P0");
+            }
+            other => panic!("expected SingleSelect P0 set, got {other:?}"),
+        }
+
+        // 編集モードは閉じている
+        assert!(state.sidebar_edit.is_none());
+    }
+
+    #[test]
+    fn test_single_select_clear_returns_clear_command() {
+        let card = make_card_with_custom_fields(
+            "1",
+            "Card A",
+            vec![CustomFieldValue::SingleSelect {
+                field_id: "fld_priority".into(),
+                option_id: "opt_p1".into(),
+                name: "P1".into(),
+                color: Some(ColumnColor::Orange),
+            }],
+        );
+        let mut state = setup_detail_with_fields(card, vec![priority_field()]);
+        state.sidebar_selected = 4;
+        state.handle_event(AppEvent::Key(key(KeyCode::Enter))); // open
+
+        // "None" 行は末尾 (options.len() = 3)
+        for _ in 0..5 {
+            state.handle_event(AppEvent::Key(key(KeyCode::Char('j'))));
+        }
+        // カーソルは末尾の None にクランプ
+        let cmd = state.handle_event(AppEvent::Key(key(KeyCode::Enter)));
+        match cmd {
+            Command::ClearCustomField { field_id, .. } => {
+                assert_eq!(field_id, "fld_priority");
+            }
+            other => panic!("expected ClearCustomField, got {other:?}"),
+        }
+
+        // 楽観更新: custom_fields からこの field が消えている
+        let card = state.selected_card_ref().unwrap();
+        assert!(
+            card.custom_fields
+                .iter()
+                .all(|v| v.field_id() != "fld_priority")
+        );
+    }
+
+    #[test]
+    fn test_number_field_opens_text_input() {
+        let card = make_card_with_custom_fields("1", "Card A", vec![]);
+        let mut state = setup_detail_with_fields(card, vec![estimate_field()]);
+        state.sidebar_selected = 4; // Estimate
+
+        state.handle_event(AppEvent::Key(key(KeyCode::Enter)));
+        match &state.sidebar_edit {
+            Some(SidebarEditMode::CustomFieldNumber { field_id, input, .. }) => {
+                assert_eq!(field_id, "fld_estimate");
+                assert!(input.is_empty());
+            }
+            other => panic!("expected CustomFieldNumber, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_number_field_accepts_digits_and_commits_on_enter() {
+        let card = make_card_with_custom_fields("1", "Card A", vec![]);
+        let mut state = setup_detail_with_fields(card, vec![estimate_field()]);
+        state.sidebar_selected = 4;
+        state.handle_event(AppEvent::Key(key(KeyCode::Enter))); // open
+
+        state.handle_event(AppEvent::Key(key(KeyCode::Char('3'))));
+        state.handle_event(AppEvent::Key(key(KeyCode::Char('.'))));
+        state.handle_event(AppEvent::Key(key(KeyCode::Char('5'))));
+        let cmd = state.handle_event(AppEvent::Key(key(KeyCode::Enter)));
+
+        match cmd {
+            Command::UpdateCustomField {
+                field_id,
+                value: CustomFieldValueInput::Number { number },
+                ..
+            } => {
+                assert_eq!(field_id, "fld_estimate");
+                assert!((number - 3.5).abs() < 1e-9);
+            }
+            other => panic!("expected UpdateCustomField Number, got {other:?}"),
+        }
+        // 楽観更新
+        let card = state.selected_card_ref().unwrap();
+        match card
+            .custom_fields
+            .iter()
+            .find(|v| v.field_id() == "fld_estimate")
+        {
+            Some(CustomFieldValue::Number { number, .. }) => {
+                assert!((*number - 3.5).abs() < 1e-9);
+            }
+            other => panic!("expected Number set, got {other:?}"),
+        }
+        assert!(state.sidebar_edit.is_none());
+    }
+
+    #[test]
+    fn test_number_field_invalid_input_keeps_edit_open() {
+        let card = make_card_with_custom_fields("1", "Card A", vec![]);
+        let mut state = setup_detail_with_fields(card, vec![estimate_field()]);
+        state.sidebar_selected = 4;
+        state.handle_event(AppEvent::Key(key(KeyCode::Enter)));
+
+        state.handle_event(AppEvent::Key(key(KeyCode::Char('a'))));
+        let cmd = state.handle_event(AppEvent::Key(key(KeyCode::Enter)));
+        assert_eq!(cmd, Command::None);
+        // 編集は閉じないまま
+        assert!(matches!(
+            state.sidebar_edit,
+            Some(SidebarEditMode::CustomFieldNumber { .. })
+        ));
+    }
+
+    #[test]
+    fn test_text_field_commits_value() {
+        let card = make_card_with_custom_fields("1", "Card A", vec![]);
+        let mut state = setup_detail_with_fields(card, vec![notes_field()]);
+        state.sidebar_selected = 4;
+        state.handle_event(AppEvent::Key(key(KeyCode::Enter))); // open
+
+        for c in "hi".chars() {
+            state.handle_event(AppEvent::Key(key(KeyCode::Char(c))));
+        }
+        let cmd = state.handle_event(AppEvent::Key(key(KeyCode::Enter)));
+        match cmd {
+            Command::UpdateCustomField {
+                value: CustomFieldValueInput::Text { text },
+                ..
+            } => {
+                assert_eq!(text, "hi");
+            }
+            other => panic!("expected Text, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_date_field_validates_yyyy_mm_dd() {
+        let card = make_card_with_custom_fields("1", "Card A", vec![]);
+        let mut state = setup_detail_with_fields(card, vec![due_field()]);
+        state.sidebar_selected = 4;
+        state.handle_event(AppEvent::Key(key(KeyCode::Enter)));
+
+        for c in "2026-04-30".chars() {
+            state.handle_event(AppEvent::Key(key(KeyCode::Char(c))));
+        }
+        let cmd = state.handle_event(AppEvent::Key(key(KeyCode::Enter)));
+        match cmd {
+            Command::UpdateCustomField {
+                value: CustomFieldValueInput::Date { date },
+                ..
+            } => assert_eq!(date, "2026-04-30"),
+            other => panic!("expected Date, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_date_field_invalid_keeps_open() {
+        let card = make_card_with_custom_fields("1", "Card A", vec![]);
+        let mut state = setup_detail_with_fields(card, vec![due_field()]);
+        state.sidebar_selected = 4;
+        state.handle_event(AppEvent::Key(key(KeyCode::Enter)));
+
+        for c in "2026/04/30".chars() {
+            state.handle_event(AppEvent::Key(key(KeyCode::Char(c))));
+        }
+        let cmd = state.handle_event(AppEvent::Key(key(KeyCode::Enter)));
+        assert_eq!(cmd, Command::None);
+        assert!(matches!(
+            state.sidebar_edit,
+            Some(SidebarEditMode::CustomFieldDate { .. })
+        ));
+    }
+
+    #[test]
+    fn test_iteration_field_selects_iteration() {
+        let card = make_card_with_custom_fields("1", "Card A", vec![]);
+        let mut state = setup_detail_with_fields(card, vec![sprint_field()]);
+        state.sidebar_selected = 4;
+        state.handle_event(AppEvent::Key(key(KeyCode::Enter))); // open
+        match &state.sidebar_edit {
+            Some(SidebarEditMode::CustomFieldIteration { iterations, .. }) => {
+                assert_eq!(iterations.len(), 2);
+            }
+            other => panic!("expected CustomFieldIteration, got {other:?}"),
+        }
+
+        // Sprint 2 を選択 (cursor=1 → j)
+        state.handle_event(AppEvent::Key(key(KeyCode::Char('j'))));
+        let cmd = state.handle_event(AppEvent::Key(key(KeyCode::Enter)));
+        match cmd {
+            Command::UpdateCustomField {
+                value: CustomFieldValueInput::Iteration { iteration_id },
+                ..
+            } => assert_eq!(iteration_id, "it_2"),
+            other => panic!("expected Iteration, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_esc_cancels_custom_field_edit() {
+        let card = make_card_with_custom_fields("1", "Card A", vec![]);
+        let mut state = setup_detail_with_fields(card, vec![estimate_field()]);
+        state.sidebar_selected = 4;
+        state.handle_event(AppEvent::Key(key(KeyCode::Enter)));
+        assert!(state.sidebar_edit.is_some());
+
+        state.handle_event(AppEvent::Key(key(KeyCode::Esc)));
+        assert!(state.sidebar_edit.is_none());
+    }
+
+    #[test]
+    fn test_custom_field_edit_disabled_in_empty_fields() {
+        // field_definitions が空なら Delete は 4 のまま
+        let card = make_card_with_custom_fields("1", "Card A", vec![]);
+        let mut state = setup_detail_with_fields(card, vec![]);
+        state.sidebar_selected = 3;
+        state.handle_event(AppEvent::Key(key(KeyCode::Char('j'))));
+        assert_eq!(state.sidebar_selected, 4); // Delete
+        state.handle_event(AppEvent::Key(key(KeyCode::Char('j'))));
+        assert_eq!(state.sidebar_selected, 4);
     }
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -84,5 +84,25 @@ pub enum Command {
         existing: Option<(String, String)>,
     },
     OpenUrl(String),
+    UpdateCustomField {
+        project_id: String,
+        item_id: String,
+        field_id: String,
+        value: CustomFieldValueInput,
+    },
+    ClearCustomField {
+        project_id: String,
+        item_id: String,
+        field_id: String,
+    },
     Batch(Vec<Command>),
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum CustomFieldValueInput {
+    SingleSelect { option_id: String },
+    Iteration { iteration_id: String },
+    Text { text: String },
+    Number { number: f64 },
+    Date { date: String },
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -27,6 +27,7 @@ pub enum AppEvent {
     CommentAdded(Result<Comment, String>),
     CommentUpdated(Result<Comment, String>),
     CommentsLoaded(Result<(String, Vec<Comment>), String>),
+    CustomFieldUpdated(Result<(), String>),
 }
 
 pub struct EventHandler {

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -3,9 +3,10 @@ use graphql_client::GraphQLQuery;
 use tokio::process::Command;
 
 use super::queries::*;
+use crate::command::CustomFieldValueInput;
 use crate::model::project::{
-    Board, Card, CardType, Column, ColumnColor, Comment, IssueState, Label, PrState,
-    ProjectSummary, Repository,
+    Board, Card, CardType, Column, ColumnColor, Comment, CustomFieldValue, FieldDefinition,
+    IssueState, IterationOption, Label, PrState, ProjectSummary, Repository, SingleSelectOption,
 };
 
 // Type aliases for readability
@@ -264,6 +265,76 @@ impl GitHubClient {
             item_id: item_id.to_string(),
         };
         self.query::<DeleteCard>(vars).await?;
+        Ok(())
+    }
+
+    pub async fn update_custom_field(
+        &self,
+        project_id: &str,
+        item_id: &str,
+        field_id: &str,
+        value: &CustomFieldValueInput,
+    ) -> anyhow::Result<()> {
+        use update_field_value::ProjectV2FieldValue;
+        let gql_value = match value {
+            CustomFieldValueInput::SingleSelect { option_id } => ProjectV2FieldValue {
+                date: None,
+                iteration_id: None,
+                number: None,
+                single_select_option_id: Some(option_id.clone()),
+                text: None,
+            },
+            CustomFieldValueInput::Iteration { iteration_id } => ProjectV2FieldValue {
+                date: None,
+                iteration_id: Some(iteration_id.clone()),
+                number: None,
+                single_select_option_id: None,
+                text: None,
+            },
+            CustomFieldValueInput::Text { text } => ProjectV2FieldValue {
+                date: None,
+                iteration_id: None,
+                number: None,
+                single_select_option_id: None,
+                text: Some(text.clone()),
+            },
+            CustomFieldValueInput::Number { number } => ProjectV2FieldValue {
+                date: None,
+                iteration_id: None,
+                number: Some(*number),
+                single_select_option_id: None,
+                text: None,
+            },
+            CustomFieldValueInput::Date { date } => ProjectV2FieldValue {
+                date: Some(date.clone()),
+                iteration_id: None,
+                number: None,
+                single_select_option_id: None,
+                text: None,
+            },
+        };
+        let vars = update_field_value::Variables {
+            project_id: project_id.to_string(),
+            item_id: item_id.to_string(),
+            field_id: field_id.to_string(),
+            value: gql_value,
+        };
+        self.query::<UpdateFieldValue>(vars).await?;
+        Ok(())
+    }
+
+    pub async fn clear_custom_field(
+        &self,
+        project_id: &str,
+        item_id: &str,
+        field_id: &str,
+    ) -> anyhow::Result<()> {
+        let vars = clear_field_value::Variables {
+            project_id: project_id.to_string(),
+            item_id: item_id.to_string(),
+            field_id: field_id.to_string(),
+        };
+        self.query::<ClearFieldValue>(vars).await?;
         Ok(())
     }
 
@@ -656,20 +727,72 @@ fn build_board(
 ) -> anyhow::Result<Board> {
     let field_nodes = field_nodes.unwrap_or_default();
 
-    // Find Status field (or first single-select as fallback)
+    // Find Status field (or first single-select as fallback) and collect other fields
     let mut first_ss: Option<(String, Vec<SSOption>)> = None;
     let mut status_match: Option<(String, Vec<SSOption>)> = None;
+    let mut field_definitions: Vec<FieldDefinition> = Vec::new();
+    let mut status_candidate_ss: Option<(String, Vec<SSOption>)> = None;
 
     for node in field_nodes.into_iter().flatten() {
-        if let FieldNodes::ProjectV2SingleSelectField(ssf) = node {
-            if ssf.name == "Status" {
-                status_match = Some((ssf.id, ssf.options));
-                break;
+        match node {
+            FieldNodes::ProjectV2SingleSelectField(ssf) => {
+                if ssf.name == "Status" {
+                    status_match = Some((ssf.id.clone(), ssf.options.clone()));
+                    continue;
+                }
+                if first_ss.is_none() && status_candidate_ss.is_none() {
+                    status_candidate_ss = Some((ssf.id.clone(), ssf.options.clone()));
+                }
+                field_definitions.push(FieldDefinition::SingleSelect {
+                    id: ssf.id,
+                    name: ssf.name,
+                    options: ssf
+                        .options
+                        .into_iter()
+                        .map(|o| SingleSelectOption {
+                            id: o.id,
+                            name: o.name,
+                            color: convert_column_color(&o.color),
+                        })
+                        .collect(),
+                });
             }
-            if first_ss.is_none() {
-                first_ss = Some((ssf.id, ssf.options));
+            FieldNodes::ProjectV2Field(f) => {
+                use project_board::ProjectV2FieldType;
+                let name = f.name;
+                let id = f.id;
+                let def = match f.data_type {
+                    ProjectV2FieldType::TEXT => FieldDefinition::Text { id, name },
+                    ProjectV2FieldType::NUMBER => FieldDefinition::Number { id, name },
+                    ProjectV2FieldType::DATE => FieldDefinition::Date { id, name },
+                    // TITLE/ASSIGNEES/LABELS/MILESTONE/LINKED_PULL_REQUESTS/REPOSITORY/REVIEWERS
+                    // 等の組み込みフィールドはスキップ
+                    _ => continue,
+                };
+                field_definitions.push(def);
+            }
+            FieldNodes::ProjectV2IterationField(f) => {
+                let iterations = f
+                    .configuration
+                    .iterations
+                    .into_iter()
+                    .map(|it| IterationOption {
+                        id: it.id,
+                        title: it.title,
+                        start_date: it.start_date,
+                    })
+                    .collect();
+                field_definitions.push(FieldDefinition::Iteration {
+                    id: f.id,
+                    name: f.name,
+                    iterations,
+                });
             }
         }
+    }
+
+    if first_ss.is_none() {
+        first_ss = status_candidate_ss;
     }
 
     let (status_field_id, options) = status_match
@@ -689,17 +812,80 @@ fn build_board(
     let mut no_status_cards = Vec::new();
 
     for item in items {
-        let card = convert_item(&item);
+        let mut card = convert_item(&item);
 
         let fv_nodes = item.field_values.nodes.unwrap_or_default();
-        let status_option_id = fv_nodes.iter().flatten().find_map(|fv| {
-            if let FVNode::ProjectV2ItemFieldSingleSelectValue(sv) = fv
-                && let SSValueField::ProjectV2SingleSelectField(f) = &sv.field
-                    && f.id == status_field_id {
-                        return sv.option_id.clone();
+        let mut status_option_id: Option<String> = None;
+        for fv in fv_nodes.iter().flatten() {
+            match fv {
+                FVNode::ProjectV2ItemFieldSingleSelectValue(sv) => {
+                    if let SSValueField::ProjectV2SingleSelectField(f) = &sv.field {
+                        if f.id == status_field_id {
+                            if let Some(oid) = sv.option_id.clone() {
+                                status_option_id = Some(oid);
+                            }
+                        } else if let Some(option_id) = sv.option_id.clone() {
+                            let def = field_definitions.iter().find(|d| d.id() == f.id);
+                            let color = match def {
+                                Some(FieldDefinition::SingleSelect { options, .. }) => options
+                                    .iter()
+                                    .find(|o| o.id == option_id)
+                                    .and_then(|o| o.color.clone()),
+                                _ => None,
+                            };
+                            card.custom_fields.push(CustomFieldValue::SingleSelect {
+                                field_id: f.id.clone(),
+                                option_id,
+                                name: sv.name.clone().unwrap_or_default(),
+                                color,
+                            });
+                        }
                     }
-            None
-        });
+                }
+                FVNode::ProjectV2ItemFieldTextValue(tv) => {
+                    use project_board::ProjectBoardNodeOnProjectV2ItemsNodesFieldValuesNodesOnProjectV2ItemFieldTextValueField as TField;
+                    if let TField::ProjectV2Field(f) = &tv.field {
+                        card.custom_fields.push(CustomFieldValue::Text {
+                            field_id: f.id.clone(),
+                            text: tv.text.clone().unwrap_or_default(),
+                        });
+                    }
+                }
+                FVNode::ProjectV2ItemFieldNumberValue(nv) => {
+                    use project_board::ProjectBoardNodeOnProjectV2ItemsNodesFieldValuesNodesOnProjectV2ItemFieldNumberValueField as NField;
+                    if let NField::ProjectV2Field(f) = &nv.field
+                        && let Some(n) = nv.number
+                    {
+                        card.custom_fields.push(CustomFieldValue::Number {
+                            field_id: f.id.clone(),
+                            number: n,
+                        });
+                    }
+                }
+                FVNode::ProjectV2ItemFieldDateValue(dv) => {
+                    use project_board::ProjectBoardNodeOnProjectV2ItemsNodesFieldValuesNodesOnProjectV2ItemFieldDateValueField as DField;
+                    if let DField::ProjectV2Field(f) = &dv.field
+                        && let Some(d) = dv.date.clone()
+                    {
+                        card.custom_fields.push(CustomFieldValue::Date {
+                            field_id: f.id.clone(),
+                            date: d,
+                        });
+                    }
+                }
+                FVNode::ProjectV2ItemFieldIterationValue(iv) => {
+                    use project_board::ProjectBoardNodeOnProjectV2ItemsNodesFieldValuesNodesOnProjectV2ItemFieldIterationValueField as IField;
+                    if let IField::ProjectV2IterationField(f) = &iv.field {
+                        card.custom_fields.push(CustomFieldValue::Iteration {
+                            field_id: f.id.clone(),
+                            iteration_id: iv.iteration_id.clone(),
+                            title: iv.title.clone(),
+                        });
+                    }
+                }
+                _ => {}
+            }
+        }
 
         match status_option_id {
             Some(opt_id) => {
@@ -730,6 +916,7 @@ fn build_board(
         status_field_id,
         columns,
         repositories,
+        field_definitions,
     })
 }
 
@@ -807,6 +994,7 @@ fn convert_item(item: &ItemNode) -> Card {
                         .collect()
                 })
                 .unwrap_or_default(),
+            custom_fields: Vec::new(),
         },
         Some(Content::PullRequest(pr)) => Card {
             item_id: item.id.clone(),
@@ -864,6 +1052,7 @@ fn convert_item(item: &ItemNode) -> Card {
                         .collect()
                 })
                 .unwrap_or_default(),
+            custom_fields: Vec::new(),
         },
         Some(Content::DraftIssue(draft)) => Card {
             item_id: item.id.clone(),
@@ -877,6 +1066,7 @@ fn convert_item(item: &ItemNode) -> Card {
             body: Some(draft.body.clone()),
             comments: Vec::new(),
             milestone: None,
+            custom_fields: Vec::new(),
         },
         None => Card {
             item_id: item.id.clone(),
@@ -890,6 +1080,7 @@ fn convert_item(item: &ItemNode) -> Card {
             body: None,
             comments: Vec::new(),
             milestone: None,
+            custom_fields: Vec::new(),
         },
     }
 }

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -826,13 +826,14 @@ fn build_board(
                             }
                         } else if let Some(option_id) = sv.option_id.clone() {
                             let def = field_definitions.iter().find(|d| d.id() == f.id);
-                            let color = match def {
-                                Some(FieldDefinition::SingleSelect { options, .. }) => options
-                                    .iter()
-                                    .find(|o| o.id == option_id)
-                                    .and_then(|o| o.color.clone()),
-                                _ => None,
+                            // 定義に存在するフィールドのみ取り込む (Status/組み込みフィールド除外)
+                            let Some(FieldDefinition::SingleSelect { options, .. }) = def else {
+                                continue;
                             };
+                            let color = options
+                                .iter()
+                                .find(|o| o.id == option_id)
+                                .and_then(|o| o.color.clone());
                             card.custom_fields.push(CustomFieldValue::SingleSelect {
                                 field_id: f.id.clone(),
                                 option_id,
@@ -844,7 +845,12 @@ fn build_board(
                 }
                 FVNode::ProjectV2ItemFieldTextValue(tv) => {
                     use project_board::ProjectBoardNodeOnProjectV2ItemsNodesFieldValuesNodesOnProjectV2ItemFieldTextValueField as TField;
-                    if let TField::ProjectV2Field(f) = &tv.field {
+                    if let TField::ProjectV2Field(f) = &tv.field
+                        && matches!(
+                            field_definitions.iter().find(|d| d.id() == f.id),
+                            Some(FieldDefinition::Text { .. })
+                        )
+                    {
                         card.custom_fields.push(CustomFieldValue::Text {
                             field_id: f.id.clone(),
                             text: tv.text.clone().unwrap_or_default(),
@@ -855,6 +861,10 @@ fn build_board(
                     use project_board::ProjectBoardNodeOnProjectV2ItemsNodesFieldValuesNodesOnProjectV2ItemFieldNumberValueField as NField;
                     if let NField::ProjectV2Field(f) = &nv.field
                         && let Some(n) = nv.number
+                        && matches!(
+                            field_definitions.iter().find(|d| d.id() == f.id),
+                            Some(FieldDefinition::Number { .. })
+                        )
                     {
                         card.custom_fields.push(CustomFieldValue::Number {
                             field_id: f.id.clone(),
@@ -866,6 +876,10 @@ fn build_board(
                     use project_board::ProjectBoardNodeOnProjectV2ItemsNodesFieldValuesNodesOnProjectV2ItemFieldDateValueField as DField;
                     if let DField::ProjectV2Field(f) = &dv.field
                         && let Some(d) = dv.date.clone()
+                        && matches!(
+                            field_definitions.iter().find(|d| d.id() == f.id),
+                            Some(FieldDefinition::Date { .. })
+                        )
                     {
                         card.custom_fields.push(CustomFieldValue::Date {
                             field_id: f.id.clone(),
@@ -875,7 +889,12 @@ fn build_board(
                 }
                 FVNode::ProjectV2ItemFieldIterationValue(iv) => {
                     use project_board::ProjectBoardNodeOnProjectV2ItemsNodesFieldValuesNodesOnProjectV2ItemFieldIterationValueField as IField;
-                    if let IField::ProjectV2IterationField(f) = &iv.field {
+                    if let IField::ProjectV2IterationField(f) = &iv.field
+                        && matches!(
+                            field_definitions.iter().find(|d| d.id() == f.id),
+                            Some(FieldDefinition::Iteration { .. })
+                        )
+                    {
                         card.custom_fields.push(CustomFieldValue::Iteration {
                             field_id: f.id.clone(),
                             iteration_id: iv.iteration_id.clone(),

--- a/src/github/graphql/clear_field_value.graphql
+++ b/src/github/graphql/clear_field_value.graphql
@@ -1,0 +1,9 @@
+mutation ClearFieldValue($projectId: ID!, $itemId: ID!, $fieldId: ID!) {
+  clearProjectV2ItemFieldValue(
+    input: { projectId: $projectId, itemId: $itemId, fieldId: $fieldId }
+  ) {
+    projectV2Item {
+      id
+    }
+  }
+}

--- a/src/github/graphql/project_board.graphql
+++ b/src/github/graphql/project_board.graphql
@@ -9,7 +9,7 @@ query ProjectBoard($projectId: ID!, $itemsCursor: String) {
           nameWithOwner
         }
       }
-      fields(first: 30) {
+      fields(first: 50) {
         nodes {
           __typename
           ... on ProjectV2SingleSelectField {
@@ -24,10 +24,18 @@ query ProjectBoard($projectId: ID!, $itemsCursor: String) {
           ... on ProjectV2Field {
             id
             name
+            dataType
           }
           ... on ProjectV2IterationField {
             id
             name
+            configuration {
+              iterations {
+                id
+                title
+                startDate
+              }
+            }
           }
         }
       }
@@ -35,7 +43,7 @@ query ProjectBoard($projectId: ID!, $itemsCursor: String) {
         pageInfo { hasNextPage endCursor }
         nodes {
           id
-          fieldValues(first: 10) {
+          fieldValues(first: 20) {
             nodes {
               __typename
               ... on ProjectV2ItemFieldSingleSelectValue {
@@ -51,6 +59,28 @@ query ProjectBoard($projectId: ID!, $itemsCursor: String) {
                 field {
                   __typename
                   ... on ProjectV2Field { id name }
+                }
+              }
+              ... on ProjectV2ItemFieldNumberValue {
+                number
+                field {
+                  __typename
+                  ... on ProjectV2Field { id name }
+                }
+              }
+              ... on ProjectV2ItemFieldDateValue {
+                date
+                field {
+                  __typename
+                  ... on ProjectV2Field { id name }
+                }
+              }
+              ... on ProjectV2ItemFieldIterationValue {
+                title
+                iterationId
+                field {
+                  __typename
+                  ... on ProjectV2IterationField { id name }
                 }
               }
             }

--- a/src/github/graphql/update_field_value.graphql
+++ b/src/github/graphql/update_field_value.graphql
@@ -1,0 +1,19 @@
+mutation UpdateFieldValue(
+  $projectId: ID!
+  $itemId: ID!
+  $fieldId: ID!
+  $value: ProjectV2FieldValue!
+) {
+  updateProjectV2ItemFieldValue(
+    input: {
+      projectId: $projectId
+      itemId: $itemId
+      fieldId: $fieldId
+      value: $value
+    }
+  ) {
+    projectV2Item {
+      id
+    }
+  }
+}

--- a/src/github/queries.rs
+++ b/src/github/queries.rs
@@ -3,6 +3,7 @@ use graphql_client::GraphQLQuery;
 #[allow(clippy::upper_case_acronyms)]
 type URI = String;
 type DateTime = String;
+type Date = String;
 
 #[derive(GraphQLQuery)]
 #[graphql(
@@ -56,7 +57,7 @@ pub struct UserProjectByNumber;
 #[graphql(
     schema_path = "schema.graphql",
     query_path = "src/github/graphql/project_board.graphql",
-    response_derives = "Debug"
+    response_derives = "Debug, Clone"
 )]
 pub struct ProjectBoard;
 
@@ -211,3 +212,19 @@ pub struct UpdateIssueComment;
     response_derives = "Debug"
 )]
 pub struct ViewerLogin;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "schema.graphql",
+    query_path = "src/github/graphql/update_field_value.graphql",
+    response_derives = "Debug"
+)]
+pub struct UpdateFieldValue;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "schema.graphql",
+    query_path = "src/github/graphql/clear_field_value.graphql",
+    response_derives = "Debug"
+)]
+pub struct ClearFieldValue;

--- a/src/model/project.rs
+++ b/src/model/project.rs
@@ -12,6 +12,7 @@ pub struct Board {
     pub status_field_id: String,
     pub columns: Vec<Column>,
     pub repositories: Vec<Repository>,
+    pub field_definitions: Vec<FieldDefinition>,
 }
 
 #[derive(Clone, Debug)]
@@ -47,6 +48,108 @@ pub struct Card {
     pub body: Option<String>,
     pub comments: Vec<Comment>,
     pub milestone: Option<String>,
+    pub custom_fields: Vec<CustomFieldValue>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum FieldDefinition {
+    SingleSelect {
+        id: String,
+        name: String,
+        options: Vec<SingleSelectOption>,
+    },
+    Text {
+        id: String,
+        name: String,
+    },
+    Number {
+        id: String,
+        name: String,
+    },
+    Date {
+        id: String,
+        name: String,
+    },
+    Iteration {
+        id: String,
+        name: String,
+        iterations: Vec<IterationOption>,
+    },
+}
+
+impl FieldDefinition {
+    pub fn id(&self) -> &str {
+        match self {
+            FieldDefinition::SingleSelect { id, .. }
+            | FieldDefinition::Text { id, .. }
+            | FieldDefinition::Number { id, .. }
+            | FieldDefinition::Date { id, .. }
+            | FieldDefinition::Iteration { id, .. } => id,
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        match self {
+            FieldDefinition::SingleSelect { name, .. }
+            | FieldDefinition::Text { name, .. }
+            | FieldDefinition::Number { name, .. }
+            | FieldDefinition::Date { name, .. }
+            | FieldDefinition::Iteration { name, .. } => name,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct SingleSelectOption {
+    pub id: String,
+    pub name: String,
+    pub color: Option<ColumnColor>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct IterationOption {
+    pub id: String,
+    pub title: String,
+    pub start_date: String,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum CustomFieldValue {
+    SingleSelect {
+        field_id: String,
+        option_id: String,
+        name: String,
+        color: Option<ColumnColor>,
+    },
+    Text {
+        field_id: String,
+        text: String,
+    },
+    Number {
+        field_id: String,
+        number: f64,
+    },
+    Date {
+        field_id: String,
+        date: String,
+    },
+    Iteration {
+        field_id: String,
+        iteration_id: String,
+        title: String,
+    },
+}
+
+impl CustomFieldValue {
+    pub fn field_id(&self) -> &str {
+        match self {
+            CustomFieldValue::SingleSelect { field_id, .. }
+            | CustomFieldValue::Text { field_id, .. }
+            | CustomFieldValue::Number { field_id, .. }
+            | CustomFieldValue::Date { field_id, .. }
+            | CustomFieldValue::Iteration { field_id, .. } => field_id,
+        }
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/model/state.rs
+++ b/src/model/state.rs
@@ -26,14 +26,11 @@ pub enum DetailPane {
     Sidebar,
 }
 
-/// サイドバーのセクション数
-pub const SIDEBAR_SECTION_COUNT: usize = 5;
-/// サイドバーセクションのインデックス
+/// サイドバーの固定セクションインデックス (0..4)。4 以降はカスタムフィールド、末尾は Delete。
 pub const SIDEBAR_STATUS: usize = 0;
 pub const SIDEBAR_ASSIGNEES: usize = 1;
 pub const SIDEBAR_LABELS: usize = 2;
 pub const SIDEBAR_MILESTONE: usize = 3;
-pub const SIDEBAR_DELETE: usize = 4;
 
 #[derive(Clone, Debug)]
 pub enum SidebarEditMode {
@@ -44,6 +41,36 @@ pub enum SidebarEditMode {
     Assignees {
         items: Vec<EditItem>,
         cursor: usize,
+    },
+    CustomFieldSingleSelect {
+        field_id: String,
+        field_name: String,
+        options: Vec<super::project::SingleSelectOption>,
+        cursor: usize,
+    },
+    CustomFieldIteration {
+        field_id: String,
+        field_name: String,
+        iterations: Vec<super::project::IterationOption>,
+        cursor: usize,
+    },
+    CustomFieldText {
+        field_id: String,
+        field_name: String,
+        input: String,
+        cursor_pos: usize,
+    },
+    CustomFieldNumber {
+        field_id: String,
+        field_name: String,
+        input: String,
+        cursor_pos: usize,
+    },
+    CustomFieldDate {
+        field_id: String,
+        field_name: String,
+        input: String,
+        cursor_pos: usize,
     },
 }
 

--- a/src/ui/card.rs
+++ b/src/ui/card.rs
@@ -3,7 +3,7 @@ use ratatui::{
     layout::Rect,
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, BorderType, Borders, Clear, Padding, Paragraph, Widget},
+    widgets::{Block, BorderType, Borders, Padding, Paragraph, Widget},
 };
 
 use crate::model::project::{Card, CardType, ColumnColor, CustomFieldValue, IssueState, PrState};
@@ -43,8 +43,6 @@ impl Widget for CardWidget<'_> {
             .padding(Padding::horizontal(1));
 
         let inner = block.inner(area);
-        // 前フレームの残渣 (隣カラムのスクロール跡等) を消すため、カード領域全体を明示的にクリア
-        Clear.render(area, buf);
         block.render(area, buf);
 
         if inner.height == 0 || inner.width == 0 {

--- a/src/ui/card.rs
+++ b/src/ui/card.rs
@@ -6,10 +6,10 @@ use ratatui::{
     widgets::{Block, BorderType, Borders, Padding, Paragraph, Widget},
 };
 
-use crate::model::project::{Card, CardType, IssueState, PrState};
+use crate::model::project::{Card, CardType, ColumnColor, CustomFieldValue, IssueState, PrState};
 use crate::ui::theme::theme;
 
-pub const CARD_HEIGHT: u16 = 5;
+pub const CARD_HEIGHT: u16 = 6;
 
 pub struct CardWidget<'a> {
     pub card: &'a Card,
@@ -120,9 +120,72 @@ impl Widget for CardWidget<'_> {
             Line::from(spans)
         };
 
-        let lines = vec![title_line, assignee_line, label_line];
+        let custom_field_line = if self.card.custom_fields.is_empty() {
+            Line::from("")
+        } else {
+            let mut spans: Vec<Span> = Vec::new();
+            for (i, v) in self.card.custom_fields.iter().enumerate() {
+                if i > 0 {
+                    spans.push(Span::raw("  "));
+                }
+                match v {
+                    CustomFieldValue::SingleSelect { name, color, .. } => {
+                        let bg = color
+                            .as_ref()
+                            .map(column_color_to_tui)
+                            .unwrap_or(theme().border_unfocused);
+                        spans.push(Span::styled(
+                            name.clone(),
+                            Style::default().fg(theme().text_inverted).bg(bg),
+                        ));
+                    }
+                    CustomFieldValue::Number { number, .. } => {
+                        let text = if number.fract() == 0.0 && number.abs() < 1e16 {
+                            format!("#{}", *number as i64)
+                        } else {
+                            format!("#{number}")
+                        };
+                        spans.push(Span::styled(text, Style::default().fg(theme().text_dim)));
+                    }
+                    CustomFieldValue::Text { text, .. } => {
+                        spans.push(Span::styled(
+                            text.clone(),
+                            Style::default().fg(theme().text_dim),
+                        ));
+                    }
+                    CustomFieldValue::Date { date, .. } => {
+                        spans.push(Span::styled(
+                            date.clone(),
+                            Style::default().fg(theme().text_dim),
+                        ));
+                    }
+                    CustomFieldValue::Iteration { title, .. } => {
+                        spans.push(Span::styled(
+                            format!("⟳ {title}"),
+                            Style::default().fg(theme().text_dim),
+                        ));
+                    }
+                }
+            }
+            Line::from(spans)
+        };
+
+        let lines = vec![title_line, assignee_line, label_line, custom_field_line];
         let paragraph = Paragraph::new(lines);
         paragraph.render(inner, buf);
+    }
+}
+
+pub fn column_color_to_tui(color: &ColumnColor) -> Color {
+    match color {
+        ColumnColor::Blue => Color::Blue,
+        ColumnColor::Gray => Color::DarkGray,
+        ColumnColor::Green => Color::Green,
+        ColumnColor::Orange => Color::Rgb(255, 165, 0),
+        ColumnColor::Pink => Color::Rgb(255, 105, 180),
+        ColumnColor::Purple => Color::Magenta,
+        ColumnColor::Red => Color::Red,
+        ColumnColor::Yellow => Color::Yellow,
     }
 }
 

--- a/src/ui/card.rs
+++ b/src/ui/card.rs
@@ -3,7 +3,7 @@ use ratatui::{
     layout::Rect,
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, BorderType, Borders, Padding, Paragraph, Widget},
+    widgets::{Block, BorderType, Borders, Clear, Padding, Paragraph, Widget},
 };
 
 use crate::model::project::{Card, CardType, ColumnColor, CustomFieldValue, IssueState, PrState};
@@ -43,6 +43,8 @@ impl Widget for CardWidget<'_> {
             .padding(Padding::horizontal(1));
 
         let inner = block.inner(area);
+        // 前フレームの残渣 (隣カラムのスクロール跡等) を消すため、カード領域全体を明示的にクリア
+        Clear.render(area, buf);
         block.render(area, buf);
 
         if inner.height == 0 || inner.width == 0 {

--- a/src/ui/detail.rs
+++ b/src/ui/detail.rs
@@ -10,10 +10,9 @@ use ratatui::{
 };
 
 use crate::app::App;
-use crate::model::project::{CardType, IssueState, PrState};
+use crate::model::project::{CardType, ColumnColor, CustomFieldValue, IssueState, PrState};
 use crate::model::state::{
-    DetailPane, SIDEBAR_ASSIGNEES, SIDEBAR_DELETE, SIDEBAR_LABELS, SIDEBAR_MILESTONE,
-    SIDEBAR_STATUS,
+    DetailPane, SIDEBAR_ASSIGNEES, SIDEBAR_LABELS, SIDEBAR_MILESTONE, SIDEBAR_STATUS,
 };
 use crate::ui::card::parse_hex_color;
 use crate::ui::theme::theme;
@@ -484,12 +483,33 @@ fn render_sidebar(frame: &mut Frame, area: Rect, app: &App) {
     )));
     lines.push(Line::from(""));
 
+    // ── Custom fields sections ──
+    let field_defs = app.state.board.as_ref().map(|b| b.field_definitions.as_slice()).unwrap_or(&[]);
+    for (i, field) in field_defs.iter().enumerate() {
+        let sidebar_idx = 4 + i;
+        let header = if focused && selected == sidebar_idx {
+            Style::default()
+                .fg(theme().accent)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            header_style
+        };
+        lines.push(Line::from(Span::styled(field.name().to_string(), header)));
+        let current = card
+            .custom_fields
+            .iter()
+            .find(|v| v.field_id() == field.id());
+        lines.push(render_custom_field_value_line(current));
+        lines.push(Line::from(""));
+    }
+
     let block = Block::default().padding(Padding::horizontal(1));
     let inner = block.inner(area);
     let btn_width = inner.width as usize;
 
     // ── Delete button ──
-    let is_delete_focused = focused && selected == SIDEBAR_DELETE;
+    let delete_idx = app.state.sidebar_delete_index();
+    let is_delete_focused = focused && selected == delete_idx;
     let btn_bg = if is_delete_focused {
         theme().red
     } else {
@@ -529,6 +549,17 @@ fn render_sidebar_edit(
     let (title, items, cursor) = match edit {
         SidebarEditMode::Labels { items, cursor } => ("Labels", items.as_slice(), *cursor),
         SidebarEditMode::Assignees { items, cursor } => ("Assignees", items.as_slice(), *cursor),
+        SidebarEditMode::CustomFieldSingleSelect { .. }
+        | SidebarEditMode::CustomFieldIteration { .. } => {
+            render_custom_field_select_edit(frame, area, edit);
+            return;
+        }
+        SidebarEditMode::CustomFieldText { .. }
+        | SidebarEditMode::CustomFieldNumber { .. }
+        | SidebarEditMode::CustomFieldDate { .. } => {
+            render_custom_field_text_edit(frame, area, edit);
+            return;
+        }
     };
 
     let header_style = Style::default()
@@ -583,6 +614,217 @@ fn render_sidebar_edit(
     if items.is_empty() {
         lines.push(Line::from(Span::styled("  (none available)", dim_style)));
     }
+
+    let block = Block::default().padding(Padding::horizontal(1));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    frame.render_widget(Paragraph::new(lines), inner);
+}
+
+fn column_color_to_tui(color: &ColumnColor) -> ratatui::style::Color {
+    use ratatui::style::Color;
+    match color {
+        ColumnColor::Blue => Color::Blue,
+        ColumnColor::Gray => Color::DarkGray,
+        ColumnColor::Green => Color::Green,
+        ColumnColor::Orange => Color::Rgb(255, 165, 0),
+        ColumnColor::Pink => Color::Rgb(255, 105, 180),
+        ColumnColor::Purple => Color::Magenta,
+        ColumnColor::Red => Color::Red,
+        ColumnColor::Yellow => Color::Yellow,
+    }
+}
+
+fn render_custom_field_value_line(current: Option<&CustomFieldValue>) -> Line<'static> {
+    let dim_style = Style::default().fg(theme().text_muted);
+    match current {
+        None => Line::from(Span::styled("  --", dim_style)),
+        Some(CustomFieldValue::SingleSelect { name, color, .. }) => {
+            let bg = color
+                .as_ref()
+                .map(column_color_to_tui)
+                .unwrap_or(theme().border_unfocused);
+            Line::from(vec![
+                Span::raw("  "),
+                Span::styled(
+                    name.clone(),
+                    Style::default().fg(theme().text_inverted).bg(bg),
+                ),
+            ])
+        }
+        Some(CustomFieldValue::Number { number, .. }) => {
+            let s = if number.fract() == 0.0 && number.abs() < 1e16 {
+                format!("  {}", *number as i64)
+            } else {
+                format!("  {number}")
+            };
+            Line::from(Span::styled(s, Style::default().fg(theme().text)))
+        }
+        Some(CustomFieldValue::Text { text, .. }) => Line::from(Span::styled(
+            format!("  {text}"),
+            Style::default().fg(theme().text),
+        )),
+        Some(CustomFieldValue::Date { date, .. }) => Line::from(Span::styled(
+            format!("  {date}"),
+            Style::default().fg(theme().text),
+        )),
+        Some(CustomFieldValue::Iteration { title, .. }) => Line::from(Span::styled(
+            format!("  ⟳ {title}"),
+            Style::default().fg(theme().text),
+        )),
+    }
+}
+
+type SelectEntry = (String, Option<ColumnColor>);
+
+fn render_custom_field_select_edit(
+    frame: &mut Frame,
+    area: Rect,
+    edit: &crate::model::state::SidebarEditMode,
+) {
+    use crate::model::state::SidebarEditMode;
+    let title: &str;
+    let entries: Vec<SelectEntry>;
+    let cursor: usize;
+    match edit {
+        SidebarEditMode::CustomFieldSingleSelect {
+            field_name,
+            options,
+            cursor: c,
+            ..
+        } => {
+            title = field_name.as_str();
+            entries = options
+                .iter()
+                .map(|o| (o.name.clone(), o.color.clone()))
+                .collect();
+            cursor = *c;
+        }
+        SidebarEditMode::CustomFieldIteration {
+            field_name,
+            iterations,
+            cursor: c,
+            ..
+        } => {
+            title = field_name.as_str();
+            entries = iterations
+                .iter()
+                .map(|it| (format!("⟳ {}", it.title), None))
+                .collect();
+            cursor = *c;
+        }
+        _ => return,
+    }
+    let has_clear = true;
+
+    let header_style = Style::default()
+        .fg(theme().accent)
+        .add_modifier(Modifier::BOLD);
+    let dim_style = Style::default().fg(theme().text_muted);
+
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    lines.push(Line::from(Span::styled(
+        format!("{title}  (Enter: select, Esc: close)"),
+        header_style,
+    )));
+    lines.push(Line::from(""));
+
+    let total = entries.len() + if has_clear { 1 } else { 0 };
+    for i in 0..total {
+        let is_cursor = i == cursor;
+        let marker = if is_cursor { "▶ " } else { "  " };
+        let marker_span = Span::styled(
+            marker.to_string(),
+            if is_cursor {
+                Style::default()
+                    .fg(theme().accent)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                dim_style
+            },
+        );
+        if i < entries.len() {
+            let (name, color) = &entries[i];
+            let body = if let Some(c) = color {
+                Span::styled(
+                    name.clone(),
+                    Style::default()
+                        .fg(theme().text_inverted)
+                        .bg(column_color_to_tui(c)),
+                )
+            } else {
+                Span::styled(name.clone(), Style::default().fg(theme().text))
+            };
+            lines.push(Line::from(vec![marker_span, body]));
+        } else {
+            // Clear ("None") row
+            lines.push(Line::from(vec![
+                marker_span,
+                Span::styled(
+                    "(none / clear)".to_string(),
+                    if is_cursor {
+                        Style::default().fg(theme().text)
+                    } else {
+                        dim_style
+                    },
+                ),
+            ]));
+        }
+    }
+
+    let block = Block::default().padding(Padding::horizontal(1));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    frame.render_widget(Paragraph::new(lines), inner);
+}
+
+fn render_custom_field_text_edit(
+    frame: &mut Frame,
+    area: Rect,
+    edit: &crate::model::state::SidebarEditMode,
+) {
+    use crate::model::state::SidebarEditMode;
+    let (title, input, hint): (&str, &str, &str) = match edit {
+        SidebarEditMode::CustomFieldText { field_name, input, .. } => {
+            (field_name.as_str(), input.as_str(), "Enter: save, Esc: cancel")
+        }
+        SidebarEditMode::CustomFieldNumber { field_name, input, .. } => (
+            field_name.as_str(),
+            input.as_str(),
+            "Enter: save (number), Esc: cancel",
+        ),
+        SidebarEditMode::CustomFieldDate { field_name, input, .. } => (
+            field_name.as_str(),
+            input.as_str(),
+            "Enter: save (YYYY-MM-DD), Esc: cancel",
+        ),
+        _ => return,
+    };
+
+    let header_style = Style::default()
+        .fg(theme().accent)
+        .add_modifier(Modifier::BOLD);
+    let dim_style = Style::default().fg(theme().text_muted);
+
+    let display = if input.is_empty() { "(empty — Enter で clear)" } else { input };
+    let input_style = if input.is_empty() {
+        dim_style
+    } else {
+        Style::default().fg(theme().text)
+    };
+
+    let lines = vec![
+        Line::from(Span::styled(
+            format!("{title}  ({hint})"),
+            header_style,
+        )),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("> ", dim_style),
+            Span::styled(display.to_string(), input_style),
+            Span::styled("_", Style::default().fg(theme().accent)),
+        ]),
+    ];
 
     let block = Block::default().padding(Padding::horizontal(1));
     let inner = block.inner(area);

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -108,13 +108,17 @@ pub fn render(frame: &mut Frame, area: Rect, keymap: &Keymap) {
     lines.push(Line::from(""));
     lines.push(Line::from(Span::styled(" Detail View (Sidebar)", section_style)));
     let sidebar_entries = vec![
-        HelpEntry { action: Action::MoveDown, description: "Navigate sections" },
+        HelpEntry { action: Action::MoveDown, description: "Navigate sections (incl. custom fields)" },
         HelpEntry { action: Action::Select, description: "Edit / Select" },
         HelpEntry { action: Action::DeleteCard, description: "Delete card" },
         HelpEntry { action: Action::NextTab, description: "Switch to content" },
         HelpEntry { action: Action::Back, description: "Back to content" },
     ];
     add_section_lines(&mut lines, keymap, KeymapMode::DetailSidebar, &sidebar_entries, key_style, desc_style);
+    lines.push(Line::from(vec![
+        Span::styled("  ──       ", key_style),
+        Span::styled("Custom fields: Enter opens picker / text input (Enter saves, Esc cancels)", desc_style),
+    ]));
 
     // View switching (hardcoded, always shown)
     lines.push(Line::from(""));


### PR DESCRIPTION
## Summary
- GitHub Projects V2 のカスタムフィールド (Priority / Estimate / Sprint / Due / Notes 等) をボード上のカード 4 行目と詳細ビューのサイドバーに表示
- SingleSelect / Number / Text / Date / Iteration の全 5 型を詳細ビューから編集可能に (楽観的更新)
- Status フィールドは既存の特別扱い (H/L/Space 移動) を維持し、カスタムフィールドは独立系統として実装

## Implementation notes
- \`FieldDefinition\` / \`CustomFieldValue\` を \`model/project.rs\` に追加、\`Board.field_definitions\` と \`Card.custom_fields\` を新設
- \`SidebarEditMode\` に 5 つの編集バリアントを追加、サイドバー行数を動的に計算 (Status/Assignees/Labels/Milestone + 可変 custom fields + Delete)
- SingleSelect/Iteration は既存 Labels/Assignees のピッカー UX を流用。Text/Number/Date は 1 行入力バーで、Enter で確定、Number/Date はバリデーション失敗時はモードを維持
- 空入力で Enter すると \`clearProjectV2ItemFieldValue\` mutation を発行してクリア
- GraphQL は \`project_board.graphql\` に Number/Date/Iteration のフラグメントを追加、\`update_field_value.graphql\` と \`clear_field_value.graphql\` を新規作成
- CARD_HEIGHT を 5 → 6 に変更し 4 行目にカスタムフィールドを色付きバッジで描画

## Test plan
- [x] \`cargo test\` - 既存 204 + 新規 12 = 216 テスト全通過 (カスタムフィールドの編集開始、確定、クリア、バリデーション、サイドバー行数拡張のユニットテストを新規追加)
- [x] \`cargo clippy -- -D warnings\` - CI 互換でクリーン
- [x] \`cargo build\` - GraphQL 型生成成功
- [ ] 手動 E2E: Priority/Estimate/Sprint/Due/Notes を持つ Project V2 で起動し、ボード表示と詳細ビューからの編集、リフレッシュ後の値保持を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)