### PR TITLE
Replace Ctrl+S submit with Submit button in new card modal

### DIFF
--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -962,35 +962,45 @@ impl AppState {
     }
 
     fn handle_create_card_key(&mut self, key: KeyEvent) -> Command {
-        // Global keys (ForceQuit, Submit, Back, Tab fields)
+        // Global keys (ForceQuit, Back, Tab fields)
         if let Some(action) = self.keymap.resolve(KeymapMode::CreateCardGlobal, &key) {
             match action {
                 Action::ForceQuit => {
                     self.should_quit = true;
                     return Command::None;
                 }
-                Action::Submit => {
-                    return self.submit_create_card();
-                }
                 Action::Back => {
                     self.mode = ViewMode::Board;
                     return Command::None;
                 }
                 Action::NextField => {
+                    let next = match self.create_card_state.focused_field {
+                        CreateCardField::Type => CreateCardField::Title,
+                        CreateCardField::Title => CreateCardField::Body,
+                        CreateCardField::Body => CreateCardField::Submit,
+                        CreateCardField::Submit => CreateCardField::Type,
+                    };
+                    // Submit が disable のときはスキップして次へ
                     self.create_card_state.focused_field =
-                        match self.create_card_state.focused_field {
-                            CreateCardField::Type => CreateCardField::Title,
-                            CreateCardField::Title => CreateCardField::Body,
-                            CreateCardField::Body => CreateCardField::Type,
+                        if next == CreateCardField::Submit && !self.can_submit_create_card() {
+                            CreateCardField::Type
+                        } else {
+                            next
                         };
                     return Command::None;
                 }
                 Action::PrevField => {
+                    let prev = match self.create_card_state.focused_field {
+                        CreateCardField::Type => CreateCardField::Submit,
+                        CreateCardField::Title => CreateCardField::Type,
+                        CreateCardField::Body => CreateCardField::Title,
+                        CreateCardField::Submit => CreateCardField::Body,
+                    };
                     self.create_card_state.focused_field =
-                        match self.create_card_state.focused_field {
-                            CreateCardField::Type => CreateCardField::Body,
-                            CreateCardField::Title => CreateCardField::Type,
-                            CreateCardField::Body => CreateCardField::Title,
+                        if prev == CreateCardField::Submit && !self.can_submit_create_card() {
+                            CreateCardField::Body
+                        } else {
+                            prev
                         };
                     return Command::None;
                 }
@@ -1013,6 +1023,14 @@ impl AppState {
                 if let Some(Action::OpenEditor) = self.keymap.resolve(KeymapMode::CreateCardBody, &key) {
                     let content = self.create_card_state.body_input.clone();
                     return Command::OpenEditor { content };
+                }
+            }
+            CreateCardField::Submit => {
+                if let Some(Action::Submit) = self.keymap.resolve(KeymapMode::CreateCardSubmit, &key) {
+                    if !self.can_submit_create_card() {
+                        return Command::None;
+                    }
+                    return self.submit_create_card();
                 }
             }
             CreateCardField::Title => {
@@ -1106,6 +1124,10 @@ impl AppState {
             project_id,
             item_id: item_id.to_string(),
         }
+    }
+
+    pub fn can_submit_create_card(&self) -> bool {
+        !self.create_card_state.title_input.trim().is_empty()
     }
 
     fn submit_create_card(&mut self) -> Command {
@@ -3528,11 +3550,9 @@ mod tests {
         state.mode = ViewMode::CreateCard;
         state.create_card_state.title_input = "New Card".into();
         state.create_card_state.body_input = "Description".into();
+        state.create_card_state.focused_field = CreateCardField::Submit;
 
-        let cmd = state.handle_event(AppEvent::Key(key_with_mod(
-            KeyCode::Char('s'),
-            KeyModifiers::CONTROL,
-        )));
+        let cmd = state.handle_event(AppEvent::Key(key(KeyCode::Enter)));
 
         assert_eq!(
             cmd,
@@ -3545,26 +3565,6 @@ mod tests {
             }
         );
         assert_eq!(state.mode, ViewMode::Board);
-    }
-
-    #[test]
-    fn test_submit_empty_title_noop() {
-        let board = make_board(vec![(
-            "Todo",
-            "opt_1",
-            vec![make_card("1", "A")],
-        )]);
-        let mut state = make_state_with_board(board);
-        state.mode = ViewMode::CreateCard;
-        state.create_card_state.title_input = "  ".into(); // 空白のみ
-
-        let cmd = state.handle_event(AppEvent::Key(key_with_mod(
-            KeyCode::Char('s'),
-            KeyModifiers::CONTROL,
-        )));
-
-        assert_eq!(cmd, Command::None);
-        assert_eq!(state.mode, ViewMode::CreateCard); // モードは変わらない
     }
 
     // ========== イベント処理 ==========
@@ -4137,6 +4137,8 @@ mod tests {
         let mut state = make_state_with_board(board);
         state.mode = ViewMode::CreateCard;
         state.create_card_state = CreateCardState::default();
+        // Submit を reachable にするためタイトルを埋める
+        state.create_card_state.title_input = "x".into();
 
         // デフォルトは Type
         assert_eq!(state.create_card_state.focused_field, CreateCardField::Type);
@@ -4149,6 +4151,10 @@ mod tests {
         state.handle_event(AppEvent::Key(key(KeyCode::Tab)));
         assert_eq!(state.create_card_state.focused_field, CreateCardField::Body);
 
+        // Tab → Submit
+        state.handle_event(AppEvent::Key(key(KeyCode::Tab)));
+        assert_eq!(state.create_card_state.focused_field, CreateCardField::Submit);
+
         // Tab → Type (ラップ)
         state.handle_event(AppEvent::Key(key(KeyCode::Tab)));
         assert_eq!(state.create_card_state.focused_field, CreateCardField::Type);
@@ -4160,11 +4166,16 @@ mod tests {
         let mut state = make_state_with_board(board);
         state.mode = ViewMode::CreateCard;
         state.create_card_state = CreateCardState::default();
+        state.create_card_state.title_input = "x".into();
 
         // デフォルトは Type
         assert_eq!(state.create_card_state.focused_field, CreateCardField::Type);
 
-        // S-Tab → Body (逆方向ラップ)
+        // S-Tab → Submit (逆方向ラップ)
+        state.handle_event(AppEvent::Key(key(KeyCode::BackTab)));
+        assert_eq!(state.create_card_state.focused_field, CreateCardField::Submit);
+
+        // S-Tab → Body
         state.handle_event(AppEvent::Key(key(KeyCode::BackTab)));
         assert_eq!(state.create_card_state.focused_field, CreateCardField::Body);
 
@@ -4177,6 +4188,34 @@ mod tests {
         assert_eq!(state.create_card_state.focused_field, CreateCardField::Type);
     }
 
+    #[test]
+    fn test_create_card_tab_skips_submit_when_disabled() {
+        let board = make_board(vec![("Todo", "opt_1", vec![make_card("1", "A")])]);
+        let mut state = make_state_with_board(board);
+        state.mode = ViewMode::CreateCard;
+        state.create_card_state = CreateCardState::default();
+        // タイトル空なので Submit は disable
+        state.create_card_state.focused_field = CreateCardField::Body;
+
+        // Body から Tab → Submit をスキップして Type へ
+        state.handle_event(AppEvent::Key(key(KeyCode::Tab)));
+        assert_eq!(state.create_card_state.focused_field, CreateCardField::Type);
+    }
+
+    #[test]
+    fn test_create_card_backtab_skips_submit_when_disabled() {
+        let board = make_board(vec![("Todo", "opt_1", vec![make_card("1", "A")])]);
+        let mut state = make_state_with_board(board);
+        state.mode = ViewMode::CreateCard;
+        state.create_card_state = CreateCardState::default();
+        // タイトル空なので Submit は disable
+        state.create_card_state.focused_field = CreateCardField::Type;
+
+        // Type から BackTab → 逆方向ラップは Submit だが disable なので Body にスキップ
+        state.handle_event(AppEvent::Key(key(KeyCode::BackTab)));
+        assert_eq!(state.create_card_state.focused_field, CreateCardField::Body);
+    }
+
     // ========== カード作成: submit ==========
 
     #[test]
@@ -4187,11 +4226,9 @@ mod tests {
         state.create_card_state.card_type = NewCardType::Draft;
         state.create_card_state.title_input = "My Draft".into();
         state.create_card_state.body_input = "body".into();
+        state.create_card_state.focused_field = CreateCardField::Submit;
 
-        let cmd = state.handle_event(AppEvent::Key(key_with_mod(
-            KeyCode::Char('s'),
-            KeyModifiers::CONTROL,
-        )));
+        let cmd = state.handle_event(AppEvent::Key(key(KeyCode::Enter)));
 
         assert_eq!(
             cmd,
@@ -4217,11 +4254,9 @@ mod tests {
         state.create_card_state.card_type = NewCardType::Issue;
         state.create_card_state.title_input = "My Issue".into();
         state.create_card_state.body_input = "body".into();
+        state.create_card_state.focused_field = CreateCardField::Submit;
 
-        let cmd = state.handle_event(AppEvent::Key(key_with_mod(
-            KeyCode::Char('s'),
-            KeyModifiers::CONTROL,
-        )));
+        let cmd = state.handle_event(AppEvent::Key(key(KeyCode::Enter)));
 
         assert_eq!(
             cmd,
@@ -4248,11 +4283,9 @@ mod tests {
         state.create_card_state.card_type = NewCardType::Issue;
         state.create_card_state.title_input = "My Issue".into();
         state.create_card_state.body_input = "body".into();
+        state.create_card_state.focused_field = CreateCardField::Submit;
 
-        let cmd = state.handle_event(AppEvent::Key(key_with_mod(
-            KeyCode::Char('s'),
-            KeyModifiers::CONTROL,
-        )));
+        let cmd = state.handle_event(AppEvent::Key(key(KeyCode::Enter)));
 
         assert_eq!(cmd, Command::None);
         assert_eq!(state.mode, ViewMode::RepoSelect);
@@ -4270,6 +4303,69 @@ mod tests {
         state.mode = ViewMode::CreateCard;
         state.create_card_state.card_type = NewCardType::Issue;
         state.create_card_state.title_input = "My Issue".into();
+        state.create_card_state.focused_field = CreateCardField::Submit;
+
+        let cmd = state.handle_event(AppEvent::Key(key(KeyCode::Enter)));
+
+        assert_eq!(cmd, Command::None);
+        assert!(matches!(state.loading, LoadingState::Error(_)));
+    }
+
+    #[test]
+    fn test_create_card_submit_button_empty_title_no_op() {
+        let board = make_board(vec![("Todo", "opt_1", vec![make_card("1", "A")])]);
+        let mut state = make_state_with_board(board);
+        state.mode = ViewMode::CreateCard;
+        state.create_card_state = CreateCardState::default();
+        state.create_card_state.focused_field = CreateCardField::Submit;
+        // title_input は空のまま
+
+        let cmd = state.handle_event(AppEvent::Key(key(KeyCode::Enter)));
+
+        assert_eq!(cmd, Command::None);
+        // モーダルを閉じず維持する (disable されたボタンを押したのと同じ)
+        assert_eq!(state.mode, ViewMode::CreateCard);
+    }
+
+    #[test]
+    fn test_create_card_submit_button_whitespace_title_no_op() {
+        let board = make_board(vec![("Todo", "opt_1", vec![make_card("1", "A")])]);
+        let mut state = make_state_with_board(board);
+        state.mode = ViewMode::CreateCard;
+        state.create_card_state = CreateCardState::default();
+        state.create_card_state.focused_field = CreateCardField::Submit;
+        state.create_card_state.title_input = "   ".into();
+
+        let cmd = state.handle_event(AppEvent::Key(key(KeyCode::Enter)));
+
+        assert_eq!(cmd, Command::None);
+        assert_eq!(state.mode, ViewMode::CreateCard);
+    }
+
+    #[test]
+    fn test_create_card_can_submit_reflects_title() {
+        let board = make_board(vec![("Todo", "opt_1", vec![make_card("1", "A")])]);
+        let mut state = make_state_with_board(board);
+        state.mode = ViewMode::CreateCard;
+        state.create_card_state = CreateCardState::default();
+
+        assert!(!state.can_submit_create_card());
+
+        state.create_card_state.title_input = "   ".into();
+        assert!(!state.can_submit_create_card());
+
+        state.create_card_state.title_input = "Valid".into();
+        assert!(state.can_submit_create_card());
+    }
+
+    #[test]
+    fn test_create_card_ctrl_s_no_longer_submits() {
+        let board = make_board(vec![("Todo", "opt_1", vec![make_card("1", "A")])]);
+        let mut state = make_state_with_board(board);
+        state.mode = ViewMode::CreateCard;
+        state.create_card_state.card_type = NewCardType::Draft;
+        state.create_card_state.title_input = "My Draft".into();
+        state.create_card_state.focused_field = CreateCardField::Type;
 
         let cmd = state.handle_event(AppEvent::Key(key_with_mod(
             KeyCode::Char('s'),
@@ -4277,7 +4373,7 @@ mod tests {
         )));
 
         assert_eq!(cmd, Command::None);
-        assert!(matches!(state.loading, LoadingState::Error(_)));
+        assert_eq!(state.mode, ViewMode::CreateCard);
     }
 
     // ========== RepoSelect ==========

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -155,6 +155,7 @@ pub enum KeymapMode {
     ReactionPicker,
     CreateCardType,
     CreateCardBody,
+    CreateCardSubmit,
     EditCardBody,
     // Structural keys for text-input modes (Esc, Enter, Ctrl+c, Ctrl+s, Tab, BackTab)
     FilterStructural,
@@ -248,9 +249,8 @@ impl Keymap {
         confirm.insert(KeyBind::key(KeyCode::Esc), Action::ConfirmNo);
         keymap.modes.insert(KeymapMode::Confirm, confirm);
 
-        // CreateCard global keys (Ctrl+c, Ctrl+s, Esc, Tab, BackTab)
+        // CreateCard global keys (Esc, Tab, BackTab)
         let mut create_card_global = HashMap::new();
-        create_card_global.insert(KeyBind::ctrl('s'), Action::Submit);
         create_card_global.insert(KeyBind::key(KeyCode::Esc), Action::Back);
         create_card_global.insert(KeyBind::key(KeyCode::Tab), Action::NextField);
         create_card_global.insert(KeyBind::key(KeyCode::BackTab), Action::PrevField);
@@ -268,6 +268,11 @@ impl Keymap {
         let mut create_card_body = HashMap::new();
         create_card_body.insert(KeyBind::key(KeyCode::Enter), Action::OpenEditor);
         keymap.modes.insert(KeymapMode::CreateCardBody, create_card_body);
+
+        // CreateCard submit button
+        let mut create_card_submit = HashMap::new();
+        create_card_submit.insert(KeyBind::key(KeyCode::Enter), Action::Submit);
+        keymap.modes.insert(KeymapMode::CreateCardSubmit, create_card_submit);
 
         // CardGrab mode
         let mut card_grab = HashMap::new();

--- a/src/model/state.rs
+++ b/src/model/state.rs
@@ -109,6 +109,7 @@ pub enum CreateCardField {
     Type,
     Title,
     Body,
+    Submit,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/ui/create_card.rs
+++ b/src/ui/create_card.rs
@@ -2,7 +2,7 @@ use ratatui::{
     layout::{Constraint, Flex, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, BorderType, Borders, Clear, Paragraph},
+    widgets::{Block, BorderType, Borders, Clear, Padding, Paragraph},
     Frame,
 };
 
@@ -10,7 +10,7 @@ use crate::model::state::{CreateCardField, CreateCardState, NewCardType};
 use crate::ui::theme::theme;
 
 pub fn render(frame: &mut Frame, area: Rect, state: &CreateCardState) {
-    let popup = centered_rect(60, 18, area);
+    let popup = centered_rect(60, 21, area);
     frame.render_widget(Clear, popup);
 
     let block = Block::default()
@@ -36,14 +36,16 @@ pub fn render(frame: &mut Frame, area: Rect, state: &CreateCardState) {
     let input_style = Style::default().fg(theme().text);
     let hint_style = Style::default().fg(theme().text_muted);
 
-    // Layout: Type (2 lines) + gap + Title box (3 lines) + gap + Body (2 lines) + gap + hints
+    // Layout: Type(2) + gap(1) + Title(3) + gap(1) + Body(2) + gap(1) + Submit(3) + hints
     let chunks = Layout::vertical([
         Constraint::Length(2), // Type
         Constraint::Length(1), // gap
         Constraint::Length(3), // Title (box)
         Constraint::Length(1), // gap
         Constraint::Length(2), // Body
-        Constraint::Min(0),   // gap + hints
+        Constraint::Length(1), // gap
+        Constraint::Length(3), // Submit button
+        Constraint::Min(0),    // hints
     ])
     .split(inner);
 
@@ -84,14 +86,19 @@ pub fn render(frame: &mut Frame, area: Rect, state: &CreateCardState) {
     };
     render_body_field(frame, chunks[4], &state.body_input, state.focused_field == CreateCardField::Body, body_label_style, hint_style);
 
+    // --- Submit button ---
+    let submit_focused = state.focused_field == CreateCardField::Submit;
+    let submit_enabled = !state.title_input.trim().is_empty();
+    render_submit_button(frame, chunks[6], submit_focused, submit_enabled);
+
     // --- Hints ---
-    let hint_area = chunks[5];
-    if hint_area.height >= 2 {
+    let hint_area = chunks[7];
+    if hint_area.height >= 1 {
         let hint_line = Line::from(vec![
             Span::raw("  "),
             Span::styled("Tab", hint_style),
             Span::styled(":switch  ", hint_style),
-            Span::styled("C-s", hint_style),
+            Span::styled("Enter", hint_style),
             Span::styled(":submit  ", hint_style),
             Span::styled("Esc", hint_style),
             Span::styled(":cancel", hint_style),
@@ -212,6 +219,51 @@ fn render_body_field(
     };
 
     frame.render_widget(Paragraph::new(vec![label_line, value_line]), area);
+}
+
+fn render_submit_button(frame: &mut Frame, area: Rect, is_focused: bool, is_enabled: bool) {
+    let outer = Block::default().padding(Padding::horizontal(1));
+    let btn_area = outer.inner(area);
+    frame.render_widget(outer, area);
+
+    if is_enabled && is_focused {
+        // active: 塗りつぶし
+        let bg = theme().green;
+        let fg = theme().text;
+        let edge = Style::default().fg(bg);
+        let fill = Style::default().fg(fg).bg(bg);
+        let width = btn_area.width as usize;
+        let label = "Submit";
+        let pad_total = width.saturating_sub(label.len());
+        let pad_left = pad_total / 2;
+        let pad_right = pad_total - pad_left;
+
+        let lines = vec![
+            Line::from(Span::styled("▄".repeat(width), edge)),
+            Line::from(Span::styled(
+                format!("{}{label}{}", " ".repeat(pad_left), " ".repeat(pad_right)),
+                fill,
+            )),
+            Line::from(Span::styled("▀".repeat(width), edge)),
+        ];
+        frame.render_widget(Paragraph::new(lines), btn_area);
+    } else {
+        // disable / unfocused: 枠のみ
+        let (border_fg, label_fg) = if is_enabled {
+            (theme().border_unfocused, theme().text)
+        } else {
+            (theme().border_unfocused, theme().text_muted)
+        };
+        let button = Block::default()
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(border_fg));
+        let inner = button.inner(btn_area);
+        frame.render_widget(button, btn_area);
+        let label_line = Line::from(Span::styled("Submit", Style::default().fg(label_fg)))
+            .alignment(ratatui::layout::Alignment::Center);
+        frame.render_widget(Paragraph::new(label_line), inner);
+    }
 }
 
 fn centered_rect(percent_x: u16, height: u16, area: Rect) -> Rect {


### PR DESCRIPTION
## Summary
- 新規カード作成モーダルの `Ctrl+S` submit を廃止し、下端に Submit ボタンを追加
- Tab/BackTab 循環に Submit を追加（Type → Title → Body → Submit）
- タイトル空の間は Submit ボタンを disable（枠のみのグレイアウト表示、Tab 循環からスキップ）
- active 時は塗りつぶし（サイドバー Delete と同じ ▄/▀ 装飾、色は green）
- ヒント行を `Tab:switch  Enter:submit  Esc:cancel` に更新

Closes #34

## Test plan
- [x] `cargo test`（269 件通過）
- [x] `cargo clippy -- -D warnings`（警告ゼロ）
- [ ] `cargo run -- --owner <org> --project <num>` で手動確認
  - [ ] `n` でモーダルを開くと Submit ボタンがグレイアウトされている
  - [ ] タイトル入力で通常色に切り替わる
  - [ ] Tab で Type→Title→Body→Submit→Type の順に移動
  - [ ] タイトル空のときは Body→Tab で Submit をスキップして Type へ
  - [ ] Submit にフォーカスすると緑の塗りつぶし、Enter で作成
  - [ ] `Ctrl+S` は反応しない
  - [ ] `Esc` でキャンセルできる

🤖 Generated with [Claude Code](https://claude.com/claude-code)