### PR TITLE
Indicate scrollable state with arrows and title counters

### DIFF
--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -1716,6 +1716,10 @@ impl AppState {
         self.scroll_offset = 0;
     }
 
+    pub fn should_show_scrollbar(total: usize, viewport: usize) -> bool {
+        viewport > 0 && total > viewport
+    }
+
     pub fn compute_board_scroll_x(
         selected_column: usize,
         current_scroll: usize,
@@ -6336,6 +6340,30 @@ mod tests {
         assert!(now);
         assert_eq!(reactions[0].count, 3);
         assert!(reactions[0].viewer_has_reacted);
+    }
+
+    // --- should_show_scrollbar tests ---
+
+    #[test]
+    fn test_should_show_scrollbar_fits() {
+        assert!(!AppState::should_show_scrollbar(5, 10));
+        assert!(!AppState::should_show_scrollbar(10, 10));
+    }
+
+    #[test]
+    fn test_should_show_scrollbar_overflow() {
+        assert!(AppState::should_show_scrollbar(11, 10));
+        assert!(AppState::should_show_scrollbar(1000, 3));
+    }
+
+    #[test]
+    fn test_should_show_scrollbar_zero_viewport() {
+        assert!(!AppState::should_show_scrollbar(100, 0));
+    }
+
+    #[test]
+    fn test_should_show_scrollbar_zero_total() {
+        assert!(!AppState::should_show_scrollbar(0, 10));
     }
 
     // --- compute_board_scroll_x tests ---

--- a/src/ui/board.rs
+++ b/src/ui/board.rs
@@ -10,6 +10,7 @@ use crate::app::App;
 use crate::app_state::AppState;
 use crate::model::state::ViewMode;
 use crate::ui::card::{CardWidget, CARD_HEIGHT};
+use crate::ui::scroll_fade::{draw_bottom_arrow, draw_left_arrow, draw_right_arrow, draw_top_arrow};
 use crate::ui::theme::theme;
 
 pub const COLUMN_WIDTH: u16 = 36;
@@ -88,25 +89,19 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
             .map(|(idx, _)| idx)
             .collect();
 
-        let title = format!(" {} ({}) ", column.name, filtered_indices.len());
-        let col_block = Block::default()
-            .title(title)
-            .title_style(title_style)
+        let total = filtered_indices.len();
+
+        // max_visible は Block::inner 計算後に確定するが、title 構築には先に仮算出する必要はない。
+        // 一旦 block を作ってから inner を求め、スクロール情報を含めた title に置き換える。
+        let tmp_block = Block::default()
             .borders(Borders::ALL)
-            .border_type(BorderType::Rounded)
-            .border_style(border_style);
+            .border_type(BorderType::Rounded);
+        let inner = tmp_block.inner(col_area);
 
-        let inner = col_block.inner(col_area);
-        frame.render_widget(col_block, col_area);
-
-        // Render cards within this column
         let max_visible = (inner.height / CARD_HEIGHT) as usize;
-        if max_visible == 0 || filtered_indices.is_empty() {
-            continue;
-        }
 
         // Calculate scroll offset for this column
-        let scroll = if is_selected_col {
+        let scroll = if is_selected_col && !filtered_indices.is_empty() && max_visible > 0 {
             let selected = app.state.selected_card.min(filtered_indices.len().saturating_sub(1));
             if selected >= app.state.scroll_offset + max_visible {
                 selected - max_visible + 1
@@ -118,6 +113,27 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
         } else {
             0
         };
+
+        // タイトル: スクロール可能なら "N-M/Total"、そうでなければ "(Total)"
+        let title = if AppState::should_show_scrollbar(total, max_visible) {
+            let start = scroll + 1;
+            let end = (scroll + max_visible).min(total);
+            format!(" {} {start}-{end}/{total} ", column.name)
+        } else {
+            format!(" {} ({}) ", column.name, total)
+        };
+        let col_block = Block::default()
+            .title(title)
+            .title_style(title_style)
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(border_style);
+
+        frame.render_widget(col_block, col_area);
+
+        if max_visible == 0 || filtered_indices.is_empty() {
+            continue;
+        }
 
         let visible_cards = filtered_indices
             .iter()
@@ -161,6 +177,28 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
         if let Some(area) = grab_shadow_area {
             render_shadow(frame.buffer_mut(), area);
         }
+
+        // カラム上下のボーダー中央に矢印を配置 (画面外にカードがあるときのみ)
+        let has_above = scroll > 0;
+        let has_below = scroll + max_visible < filtered_indices.len();
+        let buf = frame.buffer_mut();
+        if has_above {
+            draw_top_arrow(buf, col_area);
+        }
+        if has_below {
+            draw_bottom_arrow(buf, col_area);
+        }
+    }
+
+    // 横方向の矢印: カラムが左右に隠れている方向のボーダー中央に描画
+    let has_left = scroll_x > 0;
+    let has_right = end < num_cols;
+    let buf = frame.buffer_mut();
+    if has_left {
+        draw_left_arrow(buf, area);
+    }
+    if has_right {
+        draw_right_arrow(buf, area);
     }
 }
 

--- a/src/ui/comment_list.rs
+++ b/src/ui/comment_list.rs
@@ -7,6 +7,8 @@ use ratatui::{
 };
 
 use crate::app::App;
+use crate::app_state::AppState;
+use crate::ui::scroll_fade::{draw_bottom_arrow, draw_top_arrow};
 use crate::ui::theme::theme;
 
 pub fn render(frame: &mut Frame, area: Rect, app: &App) {
@@ -23,8 +25,14 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
     let popup = centered_rect(60, 70, area);
     frame.render_widget(Clear, popup);
 
+    let total_comments = card.comments.len();
+    let title = if total_comments > 0 {
+        format!(" Comments {}/{} ", cls.cursor + 1, total_comments)
+    } else {
+        " Comments ".to_string()
+    };
     let block = Block::default()
-        .title(" Comments ")
+        .title(title)
         .title_style(
             Style::default()
                 .fg(theme().accent)
@@ -133,8 +141,24 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
     .split(inner);
 
     let scroll = cls.cursor.saturating_sub(content_height / 2);
-    let paragraph = Paragraph::new(lines).scroll((scroll as u16 * 3, 0));
+    let total_lines = lines.len();
+    let viewport = vert[0].height as usize;
+    let scroll_lines = (scroll * 3).min(total_lines.saturating_sub(viewport));
+    let paragraph = Paragraph::new(lines).scroll((scroll_lines as u16, 0));
     frame.render_widget(paragraph, vert[0]);
+
+    // 矢印: popup のボーダー中央に上下矢印を描画
+    if AppState::should_show_scrollbar(total_lines, viewport) {
+        let has_above = scroll_lines > 0;
+        let has_below = scroll_lines + viewport < total_lines;
+        let buf = frame.buffer_mut();
+        if has_above {
+            draw_top_arrow(buf, popup);
+        }
+        if has_below {
+            draw_bottom_arrow(buf, popup);
+        }
+    }
 
     let hint_style = Style::default()
         .fg(theme().text)

--- a/src/ui/detail.rs
+++ b/src/ui/detail.rs
@@ -10,6 +10,7 @@ use ratatui::{
 };
 
 use crate::app::App;
+use crate::app_state::AppState;
 use crate::model::project::{
     Card, CardType, CiStatus, ColumnColor, CustomFieldValue, IssueState, PrState, ReactionSummary,
     ReviewDecision,
@@ -18,6 +19,7 @@ use crate::model::state::{
     DetailPane, SIDEBAR_ASSIGNEES, SIDEBAR_LABELS, SIDEBAR_MILESTONE, SIDEBAR_STATUS,
 };
 use crate::ui::card::parse_hex_color;
+use crate::ui::scroll_fade::{draw_bottom_arrow, draw_left_arrow, draw_right_arrow, draw_top_arrow};
 use crate::ui::theme::theme;
 
 /// A line tagged as either table content (horizontally scrollable) or normal text (wrappable).
@@ -69,6 +71,26 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
 
     let block_title = format!(" {type_icon}{number_str}{} ", card.title);
 
+    // 縦/横スクロール量のカウンタ (前フレームの Cell 値を使用)
+    let detail_max_scroll = app.state.detail_max_scroll.get();
+    let detail_max_scroll_x = app.state.detail_max_scroll_x.get();
+    let scroll_counter = {
+        let mut parts: Vec<String> = Vec::new();
+        if detail_max_scroll > 0 {
+            let s = app.state.detail_scroll.min(detail_max_scroll);
+            parts.push(format!("↕ {}/{}", s + 1, detail_max_scroll + 1));
+        }
+        if detail_max_scroll_x > 0 {
+            let sx = app.state.detail_scroll_x.min(detail_max_scroll_x);
+            parts.push(format!("↔ {}/{}", sx + 1, detail_max_scroll_x + 1));
+        }
+        if parts.is_empty() {
+            None
+        } else {
+            Some(format!(" {} ", parts.join("  ")))
+        }
+    };
+
     let sidebar_focused = app.state.detail_pane == DetailPane::Sidebar;
     let border_color = if sidebar_focused {
         theme().border_unfocused
@@ -76,7 +98,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
         theme().border_focused
     };
 
-    let block = Block::default()
+    let mut block = Block::default()
         .title(block_title)
         .title_style(
             Style::default()
@@ -86,6 +108,17 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(border_color));
+    if let Some(counter) = scroll_counter {
+        block = block.title_top(
+            Line::from(Span::styled(
+                counter,
+                Style::default()
+                    .fg(theme().accent)
+                    .add_modifier(Modifier::BOLD),
+            ))
+            .right_aligned(),
+        );
+    }
 
     let inner = block.inner(popup);
     frame.render_widget(block, popup);
@@ -338,9 +371,14 @@ fn render_content_pane(
 
     // ── Render ──
     let _ = border_color; // フォーカス表示用に将来使用可能
-    let visible = final_lines.into_iter().skip(scroll).take(content_height);
 
-    for (i, tl) in visible.enumerate() {
+    // 表示中に各行がどの幅を占めるかを取得しておく (横フェード判定用)
+    let visible_lines: Vec<_> = final_lines.into_iter().skip(scroll).take(content_height).collect();
+    let visible_has_overflow_table = visible_lines
+        .iter()
+        .any(|tl| tl.is_table && line_width(&tl.line) > content_width);
+
+    for (i, tl) in visible_lines.into_iter().enumerate() {
         let line_rect = Rect {
             x: content_inner.x,
             y: content_inner.y + i as u16,
@@ -352,6 +390,28 @@ fn render_content_pane(
             frame.render_widget(p, line_rect);
         } else {
             frame.render_widget(tl.line, line_rect);
+        }
+    }
+
+    // 矢印: 上下方向 (popup のボーダー中央に描画)
+    let has_above = scroll > 0;
+    let has_below = AppState::should_show_scrollbar(total_lines, content_height)
+        && scroll + content_height < total_lines;
+    let buf = frame.buffer_mut();
+    if has_above {
+        draw_top_arrow(buf, area);
+    }
+    if has_below {
+        draw_bottom_arrow(buf, area);
+    }
+
+    // 矢印: 横方向 (表示中のテーブル行が領域を超えている場合のみ)
+    if visible_has_overflow_table {
+        if scroll_x > 0 {
+            draw_left_arrow(buf, area);
+        }
+        if scroll_x < max_scroll_x {
+            draw_right_arrow(buf, area);
         }
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -11,6 +11,7 @@ pub mod help;
 pub mod project_list;
 pub mod reaction_picker;
 pub mod repo_select;
+pub mod scroll_fade;
 pub mod statusline;
 pub mod tab_bar;
 pub mod theme;

--- a/src/ui/project_list.rs
+++ b/src/ui/project_list.rs
@@ -7,6 +7,8 @@ use ratatui::{
 };
 
 use crate::app::App;
+use crate::app_state::AppState;
+use crate::ui::scroll_fade::{draw_bottom_arrow, draw_top_arrow};
 use crate::ui::theme::theme;
 
 pub fn render(frame: &mut Frame, area: Rect, app: &App) {
@@ -14,8 +16,18 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
 
     frame.render_widget(Clear, popup_area);
 
+    let total = app.state.projects.len();
+    let title = if total > 0 {
+        format!(
+            " Select Project {}/{} ",
+            app.state.selected_project_index + 1,
+            total
+        )
+    } else {
+        " Select Project ".to_string()
+    };
     let block = Block::default()
-        .title(" Select Project ")
+        .title(title)
         .title_style(Style::default().fg(theme().accent).add_modifier(Modifier::BOLD))
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
@@ -70,6 +82,26 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
 
     let mut state = ListState::default().with_selected(Some(app.state.selected_project_index));
     frame.render_stateful_widget(list, popup_area, &mut state);
+
+    // 矢印: popup のボーダー中央に上下矢印を描画
+    let viewport_items = popup_area.height.saturating_sub(2) as usize / 2;
+    if AppState::should_show_scrollbar(total, viewport_items) {
+        let max_offset = total.saturating_sub(viewport_items);
+        let approx_offset = app
+            .state
+            .selected_project_index
+            .saturating_sub(viewport_items / 2)
+            .min(max_offset);
+        let has_above = approx_offset > 0;
+        let has_below = approx_offset + viewport_items < total;
+        let buf = frame.buffer_mut();
+        if has_above {
+            draw_top_arrow(buf, popup_area);
+        }
+        if has_below {
+            draw_bottom_arrow(buf, popup_area);
+        }
+    }
 }
 
 fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {

--- a/src/ui/scroll_fade.rs
+++ b/src/ui/scroll_fade.rs
@@ -1,0 +1,59 @@
+use ratatui::{
+    buffer::Buffer,
+    layout::Rect,
+    style::{Modifier, Style},
+};
+
+use crate::ui::theme::theme;
+
+/// `area` の上端右寄りに上方向スクロール可能を示す ▲ 印を描く。
+/// 右上角の 2 セル内側に配置し、タイトル (左寄せ) と被らないようにする。
+pub fn draw_top_arrow(buf: &mut Buffer, area: Rect) {
+    if area.width < 3 || area.height == 0 {
+        return;
+    }
+    let y = area.y;
+    let x = area.x + area.width - 2;
+    set_arrow(buf, x, y, "▲");
+}
+
+/// `area` の下端右寄りに下方向スクロール可能を示す ▼ 印を描く。
+pub fn draw_bottom_arrow(buf: &mut Buffer, area: Rect) {
+    if area.width < 3 || area.height == 0 {
+        return;
+    }
+    let y = area.y + area.height - 1;
+    let x = area.x + area.width - 2;
+    set_arrow(buf, x, y, "▼");
+}
+
+/// `area` の左端中央に左方向スクロール可能を示す ◀ 印を描く。
+pub fn draw_left_arrow(buf: &mut Buffer, area: Rect) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+    let x = area.x;
+    let y = area.y + area.height / 2;
+    set_arrow(buf, x, y, "◀");
+}
+
+/// `area` の右端中央に右方向スクロール可能を示す ▶ 印を描く。
+pub fn draw_right_arrow(buf: &mut Buffer, area: Rect) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+    let x = area.x + area.width - 1;
+    let y = area.y + area.height / 2;
+    set_arrow(buf, x, y, "▶");
+}
+
+fn set_arrow(buf: &mut Buffer, x: u16, y: u16, symbol: &str) {
+    if let Some(cell) = buf.cell_mut((x, y)) {
+        cell.set_symbol(symbol);
+        cell.set_style(
+            Style::default()
+                .fg(theme().accent)
+                .add_modifier(Modifier::BOLD),
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fix #35. スクロール可能な状態が分かりづらい問題への対応。

- カラム・カード詳細・コメント一覧・プロジェクト一覧で、コンテンツがはみ出している方向に合わせて **▲/▼/◀/▶ 矢印** を枠線右寄りに表示
- タイトルに現在位置カウンタを追加
  - カラム: ` Status 5-7/12 ` (可視範囲/総数)
  - コメント一覧: ` Comments 3/12 `
  - プロジェクト一覧: ` Select Project 4/20 `
  - カード詳細: popup タイトル右側に ` ↕ 4/20  ↔ 2/5 `
- 共通ヘルパ \`src/ui/scroll_fade.rs\` で矢印描画を一元化
- \`AppState::should_show_scrollbar\` pure function をテスト付きで追加

## Test plan

- [ ] \`cargo test\` で全テスト pass (276 件)
- [ ] \`cargo clippy -- -D warnings\` で警告ゼロ
- [ ] カードが多いカラムで下に ▼、スクロール後上に ▲ が表示される
- [ ] カラムが多いボードで左右端に ◀ / ▶ が表示される
- [ ] カード詳細でコメントや本文が長い場合に ▲ / ▼ が表示される
- [ ] 詳細のテーブルが横に長い場合に ◀ / ▶ が表示される
- [ ] コメント一覧・プロジェクト一覧で総数超過時に矢印が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)