### PR TITLE
Show sub-issue relationships with navigable sidebar modal (closes #25)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,18 @@ curl -L -o schema.graphql https://raw.githubusercontent.com/octokit/graphql-sche
 - u: 復元 (unarchiveProjectV2Item mutation)。リストから楽観的に除去し、戻った先のボードはリフレッシュして復元カードを表示
 - 削除 (deleteProjectV2Item) 機能は archive を主操作にする方針で削除済み。物理削除が必要な場合は GitHub Web UI を使う
 
+### Sub-issue (親子関係) の表示
+- Issue.parent / Issue.subIssuesSummary はボード取得時 (ProjectBoard query) に一緒に取得
+- カード表示: 親 issue があれば `↳`、sub-issue 進捗があれば `[n/m]` (完了で green、進行中で blue)
+- 詳細ビュー サイドバー (Custom fields の後、Archive の前) に Parent / Sub-issues セクションを表示
+- sub-issue 一覧は詳細ビューを開いたときに別クエリ (`FetchSubIssues`, 最大 50 件) で遅延取得
+- サイドバーは `SidebarSection` enum (Status/Assignees/Labels/Milestone/CustomField/Parent/SubIssue/Archive) で動的レイアウト。`sidebar_sections()` が現在の card から列挙し、j/k で全セクションをナビゲート可能
+- サイドバー表示領域を超える場合は選択セクションが可視範囲に収まるよう自動スクロール (Paragraph::scroll で計算)
+- Parent / Sub-issue で Enter → `FetchIssueDetail` (node(id) ... on Issue) で Issue を取得し `detail_stack: Vec<Card>` に push してモーダル積み上げ表示
+- Esc / q で 1 段戻る (`pop_detail_stack`)。スタックが空なら従来どおり Board に戻る
+- detail_stack 上の Issue はボード外なので、サイドバーの編集系 (Status 変更/Label 編集/Archive/CustomField) は無効化 (Parent/SubIssue の移動のみ許可)
+- `current_detail_card()` が詳細描画の唯一の窓口 (detail_stack 先頭 → なければ selected_card_ref)
+
 ### コメント操作
 - c (詳細ビュー Content ペイン): 新規コメント投稿 ($EDITOR 起動、addComment mutation)
 - C (詳細ビュー Content ペイン): コメント一覧 (ViewMode::CommentList) を開く

--- a/src/app.rs
+++ b/src/app.rs
@@ -356,6 +356,26 @@ impl App {
                     ));
                 });
             }
+            Command::FetchSubIssues { item_id, content_id } => {
+                let client = self.github.clone();
+                let tx = self.event_tx.clone();
+                tokio::spawn(async move {
+                    let result = client.fetch_sub_issues(&content_id).await;
+                    let _ = tx.send(AppEvent::SubIssuesLoaded(
+                        result.map(|subs| (item_id, subs)).map_err(|e| e.to_string()),
+                    ));
+                });
+            }
+            Command::FetchIssueDetail { content_id } => {
+                let client = self.github.clone();
+                let tx = self.event_tx.clone();
+                tokio::spawn(async move {
+                    let result = client.fetch_issue_as_card(&content_id).await;
+                    let _ = tx.send(AppEvent::IssueDetailLoaded(
+                        result.map(Box::new).map_err(|e| e.to_string()),
+                    ));
+                });
+            }
             Command::OpenEditorForComment {
                 content_id,
                 existing,

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -40,9 +40,10 @@ use crate::model::state::{
     ActiveFilter, CommentListState, ConfirmAction, ConfirmState, CreateCardField,
     CreateCardState, DetailPane, EditCardField, EditCardState, EditItem, FilterState, GrabState,
     GroupBySelectState, LoadingState, NewCardType, PendingIssueCreate, ReactionPickerState,
-    ReactionTarget, RepoSelectState, SidebarEditMode, ViewMode, SIDEBAR_ASSIGNEES, SIDEBAR_LABELS,
-    SIDEBAR_STATUS,
+    ReactionTarget, RepoSelectState, SidebarEditMode, SidebarSection, ViewMode,
 };
+#[cfg(test)]
+use crate::model::state::{SIDEBAR_ASSIGNEES, SIDEBAR_LABELS};
 
 pub struct AppState {
     pub mode: ViewMode,
@@ -85,6 +86,11 @@ pub struct AppState {
     pub status_select_open: bool,
     pub status_select_cursor: usize,
     pub sidebar_edit: Option<SidebarEditMode>,
+    /// Parent / Sub-issue を Enter で開いた時のオーバーレイスタック。
+    /// 末尾が現在表示中のカード (current_detail_card)。空ならボードの selected を表示。
+    pub detail_stack: Vec<Card>,
+    /// FetchIssueDetail 中の判定 (重複発行防止)
+    pub detail_loading_id: Option<String>,
 
     // Edit card
     pub edit_card_state: Option<EditCardState>,
@@ -158,6 +164,8 @@ impl AppState {
             status_select_open: false,
             status_select_cursor: 0,
             sidebar_edit: None,
+            detail_stack: Vec::new(),
+            detail_loading_id: None,
             edit_card_state: None,
             grab_state: None,
             comment_list_state: None,
@@ -555,6 +563,56 @@ impl AppState {
                 Command::None
             }
             AppEvent::CommentsLoaded(Err(e)) => {
+                self.loading = LoadingState::Error(e);
+                Command::None
+            }
+            AppEvent::SubIssuesLoaded(Ok((item_id, sub_issues))) => {
+                // detail_stack のトップにも反映 (FetchIssueDetail で開いた Issue が item_id を共有)
+                if let Some(top) = self.detail_stack.last_mut()
+                    && top.item_id == item_id
+                {
+                    top.sub_issues = sub_issues.clone();
+                }
+                if let Some(board) = &mut self.board {
+                    for col in &mut board.columns {
+                        for card in &mut col.cards {
+                            if card.item_id == item_id {
+                                card.sub_issues = sub_issues;
+                                return Command::None;
+                            }
+                        }
+                    }
+                }
+                Command::None
+            }
+            AppEvent::SubIssuesLoaded(Err(e)) => {
+                self.loading = LoadingState::Error(e);
+                Command::None
+            }
+            AppEvent::IssueDetailLoaded(Ok(card)) => {
+                self.detail_loading_id = None;
+                let card = *card;
+                let needs_subs = matches!(card.card_type, CardType::Issue { .. })
+                    && card
+                        .sub_issues_summary
+                        .as_ref()
+                        .is_some_and(|s| s.total > 0);
+                let item_id = card.item_id.clone();
+                let content_id = card.content_id.clone();
+                self.push_detail_stack(card);
+                self.mode = ViewMode::Detail;
+                if needs_subs
+                    && let Some(cid) = content_id
+                {
+                    return Command::FetchSubIssues {
+                        item_id,
+                        content_id: cid,
+                    };
+                }
+                Command::None
+            }
+            AppEvent::IssueDetailLoaded(Err(e)) => {
+                self.detail_loading_id = None;
                 self.loading = LoadingState::Error(e);
                 Command::None
             }
@@ -1969,12 +2027,34 @@ impl AppState {
         self.mode = ViewMode::Detail;
 
         // コメントが20件（上限）の場合、追加コメントを取得
-        if let Some(card) = self.selected_card_ref()
-            && card.comments.len() >= 20
-                && let Some(content_id) = card.content_id.clone() {
-                    return Command::FetchComments { content_id };
-                }
-        Command::None
+        // sub-issue サマリーを持つ Issue の場合、子 Issue 一覧を取得
+        let mut commands: Vec<Command> = Vec::new();
+        if let Some(card) = self.selected_card_ref() {
+            let content_id = card.content_id.clone();
+            if card.comments.len() >= 20
+                && let Some(cid) = content_id.clone()
+            {
+                commands.push(Command::FetchComments { content_id: cid });
+            }
+            let needs_sub_issues = matches!(card.card_type, CardType::Issue { .. })
+                && card
+                    .sub_issues_summary
+                    .as_ref()
+                    .is_some_and(|s| s.total > 0);
+            if needs_sub_issues
+                && let Some(cid) = content_id
+            {
+                commands.push(Command::FetchSubIssues {
+                    item_id: card.item_id.clone(),
+                    content_id: cid,
+                });
+            }
+        }
+        match commands.len() {
+            0 => Command::None,
+            1 => commands.into_iter().next().unwrap(),
+            _ => Command::Batch(commands),
+        }
     }
 
     fn handle_detail_key(&mut self, key: KeyEvent) -> Command {
@@ -2007,13 +2087,15 @@ impl AppState {
 
         match action {
             Action::Quit => {
-                self.mode = ViewMode::Board;
+                if !self.pop_detail_stack() {
+                    self.mode = ViewMode::Board;
+                }
                 Command::None
             }
             Action::Back => {
                 if self.detail_pane == DetailPane::Sidebar {
                     self.detail_pane = DetailPane::Content;
-                } else {
+                } else if !self.pop_detail_stack() {
                     self.mode = ViewMode::Board;
                 }
                 Command::None
@@ -2254,24 +2336,62 @@ impl AppState {
         }
     }
 
-    /// サイドバーの総セクション数 (Status/Assignees/Labels/Milestone + custom_fields + Archive)
+    /// 現在の詳細ビュー対象カード (detail_stack 優先、なければ board 上の selected)
+    pub fn current_detail_card(&self) -> Option<&Card> {
+        if let Some(last) = self.detail_stack.last() {
+            return Some(last);
+        }
+        self.selected_card_ref()
+    }
+
+    /// サイドバーの論理セクションを動的に列挙する。
+    /// selected card に parent / sub-issues があれば追加し、末尾は Archive。
+    pub fn sidebar_sections(&self) -> Vec<SidebarSection> {
+        let mut sections = vec![
+            SidebarSection::Status,
+            SidebarSection::Assignees,
+            SidebarSection::Labels,
+            SidebarSection::Milestone,
+        ];
+        for (i, _) in self.field_definitions().iter().enumerate() {
+            sections.push(SidebarSection::CustomField(i));
+        }
+        if let Some(card) = self.current_detail_card()
+            && matches!(card.card_type, CardType::Issue { .. })
+        {
+            if card.parent_issue.is_some() {
+                sections.push(SidebarSection::Parent);
+            }
+            let has_subs = card
+                .sub_issues_summary
+                .as_ref()
+                .is_some_and(|s| s.total > 0);
+            if has_subs {
+                // summary はあっても sub_issues がまだ空 (ロード前) の可能性もある。
+                // 実データが揃っていればその数だけ選択可能行を出す。
+                for (i, _) in card.sub_issues.iter().enumerate() {
+                    sections.push(SidebarSection::SubIssue(i));
+                }
+            }
+        }
+        sections.push(SidebarSection::Archive);
+        sections
+    }
+
+    pub fn sidebar_section_at(&self, index: usize) -> Option<SidebarSection> {
+        self.sidebar_sections().into_iter().nth(index)
+    }
+
+    /// サイドバーの総セクション数
     pub fn sidebar_section_count(&self) -> usize {
-        4 + self.field_definitions().len() + 1
+        self.sidebar_sections().len()
     }
 
     /// Archive セクションのインデックス (動的)
     pub fn sidebar_archive_index(&self) -> usize {
-        4 + self.field_definitions().len()
+        self.sidebar_section_count().saturating_sub(1)
     }
 
-    /// サイドバーインデックスが カスタムフィールド行なら、対応する FieldDefinition の index を返す
-    pub fn sidebar_field_index(&self, sidebar_index: usize) -> Option<usize> {
-        if sidebar_index >= 4 && sidebar_index < self.sidebar_archive_index() {
-            Some(sidebar_index - 4)
-        } else {
-            None
-        }
-    }
 
     fn field_definitions(&self) -> &[FieldDefinition] {
         self.board
@@ -2292,26 +2412,30 @@ impl AppState {
                 Command::None
             }
             Action::Select => {
-                let idx = self.sidebar_selected;
-                let archive_idx = self.sidebar_archive_index();
-                match idx {
-                    SIDEBAR_STATUS => {
+                let section = self.sidebar_section_at(self.sidebar_selected);
+                // detail_stack 上の Issue (ボード外) は編集系操作を無効にし、
+                // ナビゲーション (Parent / SubIssue) のみ受け付ける
+                let is_stacked = !self.detail_stack.is_empty();
+                match section {
+                    Some(SidebarSection::Parent) => self.open_parent_detail(),
+                    Some(SidebarSection::SubIssue(i)) => self.open_sub_issue_detail(i),
+                    _ if is_stacked => Command::None,
+                    Some(SidebarSection::Status) => {
                         self.status_select_open = true;
                         self.status_select_cursor = self.selected_column;
                         Command::None
                     }
-                    SIDEBAR_LABELS => self.open_label_edit(),
-                    SIDEBAR_ASSIGNEES => self.open_assignee_edit(),
-                    i if i == archive_idx => {
+                    Some(SidebarSection::Labels) => self.open_label_edit(),
+                    Some(SidebarSection::Assignees) => self.open_assignee_edit(),
+                    Some(SidebarSection::Archive) => {
                         self.start_archive_card(ViewMode::Detail);
                         Command::None
                     }
-                    _ => {
-                        if let Some(field_idx) = self.sidebar_field_index(idx) {
-                            self.open_custom_field_edit(field_idx);
-                        }
+                    Some(SidebarSection::CustomField(i)) => {
+                        self.open_custom_field_edit(i);
                         Command::None
                     }
+                    Some(SidebarSection::Milestone) | None => Command::None,
                 }
             }
             Action::ArchiveCard => {
@@ -2320,6 +2444,62 @@ impl AppState {
             }
             _ => Command::None,
         }
+    }
+
+    fn open_parent_detail(&mut self) -> Command {
+        let Some(card) = self.current_detail_card() else {
+            return Command::None;
+        };
+        let Some(parent) = card.parent_issue.as_ref() else {
+            return Command::None;
+        };
+        let id = parent.id.clone();
+        if self.detail_loading_id.as_deref() == Some(&id) {
+            return Command::None;
+        }
+        self.detail_loading_id = Some(id.clone());
+        Command::FetchIssueDetail { content_id: id }
+    }
+
+    fn open_sub_issue_detail(&mut self, idx: usize) -> Command {
+        let Some(card) = self.current_detail_card() else {
+            return Command::None;
+        };
+        let Some(sub) = card.sub_issues.get(idx) else {
+            return Command::None;
+        };
+        let id = sub.id.clone();
+        if self.detail_loading_id.as_deref() == Some(&id) {
+            return Command::None;
+        }
+        self.detail_loading_id = Some(id.clone());
+        Command::FetchIssueDetail { content_id: id }
+    }
+
+    /// detail_stack を 1 段戻す。空なら false (詳細ビュー自体を閉じる)。
+    pub fn pop_detail_stack(&mut self) -> bool {
+        if self.detail_stack.pop().is_some() {
+            self.sidebar_selected = 0;
+            self.detail_scroll = 0;
+            self.detail_scroll_x = 0;
+            self.detail_pane = DetailPane::Content;
+            self.sidebar_edit = None;
+            self.status_select_open = false;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// FetchIssueDetail で取得した Card を detail_stack に push し、表示状態をリセット
+    pub fn push_detail_stack(&mut self, card: Card) {
+        self.detail_stack.push(card);
+        self.sidebar_selected = 0;
+        self.detail_scroll = 0;
+        self.detail_scroll_x = 0;
+        self.detail_pane = DetailPane::Content;
+        self.sidebar_edit = None;
+        self.status_select_open = false;
     }
 
     fn open_custom_field_edit(&mut self, field_idx: usize) {
@@ -3418,6 +3598,9 @@ mod tests {
             linked_prs: vec![],
             reactions: vec![],
             archived: false,
+            parent_issue: None,
+            sub_issues_summary: None,
+            sub_issues: vec![],
         }
     }
 
@@ -3446,6 +3629,9 @@ mod tests {
             linked_prs: vec![],
             reactions: vec![],
             archived: false,
+            parent_issue: None,
+            sub_issues_summary: None,
+            sub_issues: vec![],
         }
     }
 
@@ -3467,6 +3653,9 @@ mod tests {
             linked_prs: vec![],
             reactions: vec![],
             archived: false,
+            parent_issue: None,
+            sub_issues_summary: None,
+            sub_issues: vec![],
         }
     }
 
@@ -3488,6 +3677,9 @@ mod tests {
             linked_prs: vec![],
             reactions: vec![],
             archived: false,
+            parent_issue: None,
+            sub_issues_summary: None,
+            sub_issues: vec![],
         }
     }
 
@@ -3513,6 +3705,9 @@ mod tests {
             linked_prs: vec![],
             reactions: vec![],
             archived: false,
+            parent_issue: None,
+            sub_issues_summary: None,
+            sub_issues: vec![],
         }
     }
 
@@ -5936,6 +6131,9 @@ mod tests {
             linked_prs: vec![],
             reactions: vec![],
             archived: false,
+            parent_issue: None,
+            sub_issues_summary: None,
+            sub_issues: vec![],
         }
     }
 
@@ -6100,6 +6298,9 @@ mod tests {
             linked_prs: vec![],
             reactions: vec![],
             archived: false,
+            parent_issue: None,
+            sub_issues_summary: None,
+            sub_issues: vec![],
         }
     }
 
@@ -6385,6 +6586,9 @@ mod tests {
             linked_prs: vec![],
             reactions: vec![],
             archived: false,
+            parent_issue: None,
+            sub_issues_summary: None,
+            sub_issues: vec![],
         }
     }
 
@@ -6634,6 +6838,184 @@ mod tests {
 
         let card = &state.board.as_ref().unwrap().columns[0].cards[0];
         assert_eq!(card.comments[0].body, "updated body");
+    }
+
+    #[test]
+    fn test_detail_opens_fetch_sub_issues_when_has_summary() {
+        use crate::model::project::SubIssuesSummary;
+        let mut card = make_issue_card("1", "Parent");
+        card.sub_issues_summary = Some(SubIssuesSummary { completed: 1, total: 3 });
+        let board = make_board(vec![("Todo", "opt_1", vec![card])]);
+        let mut state = make_state_with_board(board);
+
+        let cmd = state.handle_event(AppEvent::Key(key(KeyCode::Enter)));
+        assert_eq!(state.mode, ViewMode::Detail);
+        assert_eq!(
+            cmd,
+            Command::FetchSubIssues {
+                item_id: "1".into(),
+                content_id: "issue_1".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_detail_no_fetch_sub_issues_when_summary_empty() {
+        use crate::model::project::SubIssuesSummary;
+        let mut card = make_issue_card("1", "No subs");
+        card.sub_issues_summary = Some(SubIssuesSummary { completed: 0, total: 0 });
+        let board = make_board(vec![("Todo", "opt_1", vec![card])]);
+        let mut state = make_state_with_board(board);
+
+        let cmd = state.handle_event(AppEvent::Key(key(KeyCode::Enter)));
+        assert_eq!(cmd, Command::None);
+    }
+
+    #[test]
+    fn test_detail_no_fetch_sub_issues_for_draft() {
+        let card = make_draft_card("1", "Draft", "body");
+        let board = make_board(vec![("Todo", "opt_1", vec![card])]);
+        let mut state = make_state_with_board(board);
+
+        let cmd = state.handle_event(AppEvent::Key(key(KeyCode::Enter)));
+        assert_eq!(cmd, Command::None);
+    }
+
+    #[test]
+    fn test_sidebar_sections_includes_parent_and_subs() {
+        use crate::model::project::{IssueState, ParentIssueRef, SubIssueRef, SubIssuesSummary};
+        let mut card = make_issue_card("1", "Parent");
+        card.parent_issue = Some(ParentIssueRef {
+            id: "p1".into(),
+            number: 9,
+            title: "Parent Issue".into(),
+            url: None,
+        });
+        card.sub_issues_summary = Some(SubIssuesSummary { completed: 0, total: 2 });
+        card.sub_issues = vec![
+            SubIssueRef {
+                id: "s1".into(),
+                number: 10,
+                title: "A".into(),
+                state: IssueState::Open,
+                url: None,
+            },
+            SubIssueRef {
+                id: "s2".into(),
+                number: 11,
+                title: "B".into(),
+                state: IssueState::Closed,
+                url: None,
+            },
+        ];
+        let board = make_board(vec![("Todo", "opt_1", vec![card])]);
+        let state = make_state_with_board(board);
+
+        let sections = state.sidebar_sections();
+        // Status, Assignees, Labels, Milestone, Parent, SubIssue(0), SubIssue(1), Archive
+        assert_eq!(sections.len(), 8);
+        assert!(matches!(sections[4], SidebarSection::Parent));
+        assert!(matches!(sections[5], SidebarSection::SubIssue(0)));
+        assert!(matches!(sections[6], SidebarSection::SubIssue(1)));
+        assert!(matches!(sections[7], SidebarSection::Archive));
+    }
+
+    #[test]
+    fn test_enter_on_sub_issue_fetches_issue_detail() {
+        use crate::model::project::{IssueState, SubIssueRef, SubIssuesSummary};
+        let mut card = make_issue_card("1", "Parent");
+        card.sub_issues_summary = Some(SubIssuesSummary { completed: 0, total: 1 });
+        card.sub_issues = vec![SubIssueRef {
+            id: "sub1".into(),
+            number: 10,
+            title: "Child".into(),
+            state: IssueState::Open,
+            url: None,
+        }];
+        let board = make_board(vec![("Todo", "opt_1", vec![card])]);
+        let mut state = make_state_with_board(board);
+        state.mode = ViewMode::Detail;
+        state.detail_pane = DetailPane::Sidebar;
+        // sections: Status(0) Assignees(1) Labels(2) Milestone(3) Parent?(no)  SubIssue(0)=4 Archive=5
+        state.sidebar_selected = 4;
+
+        let cmd = state.handle_event(AppEvent::Key(key(KeyCode::Enter)));
+        assert_eq!(
+            cmd,
+            Command::FetchIssueDetail {
+                content_id: "sub1".into(),
+            }
+        );
+        assert_eq!(state.detail_loading_id.as_deref(), Some("sub1"));
+    }
+
+    #[test]
+    fn test_issue_detail_loaded_pushes_stack() {
+        let card = make_issue_card("1", "Parent");
+        let board = make_board(vec![("Todo", "opt_1", vec![card])]);
+        let mut state = make_state_with_board(board);
+        state.mode = ViewMode::Detail;
+
+        let mut overlay = make_issue_card("sub1", "Child");
+        overlay.item_id = "sub1".into();
+        overlay.content_id = Some("sub1".into());
+        overlay.number = Some(10);
+
+        let _ = state.handle_event(AppEvent::IssueDetailLoaded(Ok(Box::new(overlay.clone()))));
+        assert_eq!(state.detail_stack.len(), 1);
+        assert_eq!(state.current_detail_card().unwrap().title, "Child");
+        assert!(state.detail_loading_id.is_none());
+    }
+
+    #[test]
+    fn test_esc_pops_detail_stack_before_closing() {
+        let card = make_issue_card("1", "Parent");
+        let board = make_board(vec![("Todo", "opt_1", vec![card])]);
+        let mut state = make_state_with_board(board);
+        state.mode = ViewMode::Detail;
+        let overlay = make_issue_card("sub1", "Child");
+        state.push_detail_stack(overlay);
+        assert_eq!(state.detail_stack.len(), 1);
+
+        // 1回目 Esc: stack を pop、Detail のまま
+        let _ = state.handle_event(AppEvent::Key(key(KeyCode::Esc)));
+        assert_eq!(state.mode, ViewMode::Detail);
+        assert_eq!(state.detail_stack.len(), 0);
+
+        // 2回目 Esc: 通常通り Board に戻る
+        let _ = state.handle_event(AppEvent::Key(key(KeyCode::Esc)));
+        assert_eq!(state.mode, ViewMode::Board);
+    }
+
+    #[test]
+    fn test_sub_issues_loaded_updates_card() {
+        use crate::model::project::{IssueState, SubIssueRef};
+        let card = make_issue_card("1", "Parent");
+        let board = make_board(vec![("Todo", "opt_1", vec![card])]);
+        let mut state = make_state_with_board(board);
+
+        let subs = vec![
+            SubIssueRef {
+                id: "sub1".into(),
+                number: 10,
+                title: "Child A".into(),
+                state: IssueState::Open,
+                url: Some("https://github.com/owner/repo/issues/10".into()),
+            },
+            SubIssueRef {
+                id: "sub2".into(),
+                number: 11,
+                title: "Child B".into(),
+                state: IssueState::Closed,
+                url: None,
+            },
+        ];
+        let _ = state.handle_event(AppEvent::SubIssuesLoaded(Ok(("1".into(), subs))));
+
+        let card = &state.board.as_ref().unwrap().columns[0].cards[0];
+        assert_eq!(card.sub_issues.len(), 2);
+        assert_eq!(card.sub_issues[0].number, 10);
+        assert_eq!(card.sub_issues[1].state, IssueState::Closed);
     }
 
     #[test]

--- a/src/command.rs
+++ b/src/command.rs
@@ -89,6 +89,14 @@ pub enum Command {
     FetchComments {
         content_id: String,
     },
+    FetchSubIssues {
+        item_id: String,
+        content_id: String,
+    },
+    /// Parent / Sub-issue の Issue 詳細を取得 (detail_stack に積み上げて表示)
+    FetchIssueDetail {
+        content_id: String,
+    },
     OpenEditorForComment {
         content_id: String,
         existing: Option<(String, String)>,

--- a/src/event.rs
+++ b/src/event.rs
@@ -5,7 +5,7 @@ use futures::StreamExt;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 
-use crate::model::project::{Board, Card, Comment, Label, ProjectSummary};
+use crate::model::project::{Board, Card, Comment, Label, ProjectSummary, SubIssueRef};
 
 pub enum AppEvent {
     Key(KeyEvent),
@@ -29,6 +29,8 @@ pub enum AppEvent {
     CommentAdded(Result<Comment, String>),
     CommentUpdated(Result<Comment, String>),
     CommentsLoaded(Result<(String, Vec<Comment>), String>),
+    SubIssuesLoaded(Result<(String, Vec<SubIssueRef>), String>),
+    IssueDetailLoaded(Result<Box<Card>, String>),
     CustomFieldUpdated(Result<(), String>),
     ReactionToggled(Result<(), String>),
 }

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -6,9 +6,9 @@ use super::queries::*;
 use crate::command::CustomFieldValueInput;
 use crate::model::project::{
     Board, Card, CardType, CiStatus, Column, ColumnColor, Comment, CustomFieldValue,
-    FieldDefinition, Grouping, IssueState, IterationOption, Label, LinkedPr, PrState, PrStatus,
-    ProjectSummary, ReactionContent, ReactionSummary, Repository, ReviewDecision,
-    SingleSelectOption,
+    FieldDefinition, Grouping, IssueState, IterationOption, Label, LinkedPr, ParentIssueRef,
+    PrState, PrStatus, ProjectSummary, ReactionContent, ReactionSummary, Repository,
+    ReviewDecision, SingleSelectOption, SubIssueRef, SubIssuesSummary,
 };
 
 // ReactionContent 変換: 各 GraphQL クエリごとに自動生成される enum を model 側の型に変換する。
@@ -43,6 +43,7 @@ impl_reaction_content_from!(fetch_comments::ReactionContent);
 impl_reaction_content_from!(add_comment::ReactionContent);
 impl_reaction_content_from!(add_reaction_mutation::ReactionContent);
 impl_reaction_content_from!(remove_reaction_mutation::ReactionContent);
+impl_reaction_content_from!(fetch_issue::ReactionContent);
 
 // Type aliases for readability
 use project_board::{
@@ -783,6 +784,152 @@ impl GitHubClient {
         Ok(all_comments)
     }
 
+    /// Issue を id で取得し、Card 化して返す (Parent / Sub-issue モーダル表示用)。
+    /// item_id は board 上に対応するカードがあればそれ、なければ content_id を流用 (ボード外 issue)。
+    pub async fn fetch_issue_as_card(&self, content_id: &str) -> anyhow::Result<Card> {
+        let vars = fetch_issue::Variables {
+            id: content_id.to_string(),
+        };
+        let data = self.query::<FetchIssue>(vars).await?;
+        let node = data.node.context("Node not found")?;
+        let fetch_issue::FetchIssueNode::Issue(issue) = node else {
+            bail!("Node is not an Issue");
+        };
+        let assignees = issue
+            .assignees
+            .nodes
+            .as_ref()
+            .map(|n| n.iter().flatten().map(|u| u.login.clone()).collect())
+            .unwrap_or_default();
+        let labels = issue
+            .labels
+            .as_ref()
+            .and_then(|l| l.nodes.as_ref())
+            .map(|n| {
+                n.iter()
+                    .flatten()
+                    .map(|l| Label {
+                        id: l.id.clone(),
+                        name: l.name.clone(),
+                        color: l.color.clone(),
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        let comments = issue
+            .comments
+            .nodes
+            .as_ref()
+            .map(|n| {
+                n.iter()
+                    .flatten()
+                    .map(|c| Comment {
+                        id: c.id.clone(),
+                        author: c
+                            .author
+                            .as_ref()
+                            .map(|a| a.login.clone())
+                            .unwrap_or_else(|| "ghost".into()),
+                        body: c.body.clone(),
+                        created_at: c.created_at.clone(),
+                        reactions: c
+                            .reaction_groups
+                            .as_ref()
+                            .map(|gs| {
+                                gs.iter()
+                                    .filter_map(|g| {
+                                        Some(ReactionSummary {
+                                            content: g.content.to_model()?,
+                                            count: g.reactors.total_count as usize,
+                                            viewer_has_reacted: g.viewer_has_reacted,
+                                        })
+                                    })
+                                    .collect()
+                            })
+                            .unwrap_or_default(),
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        let reactions = issue
+            .reaction_groups
+            .as_ref()
+            .map(|gs| {
+                gs.iter()
+                    .filter_map(|g| {
+                        Some(ReactionSummary {
+                            content: g.content.to_model()?,
+                            count: g.reactors.total_count as usize,
+                            viewer_has_reacted: g.viewer_has_reacted,
+                        })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        let state = match issue.state {
+            fetch_issue::IssueState::CLOSED => IssueState::Closed,
+            _ => IssueState::Open,
+        };
+        Ok(Card {
+            // Parent/Sub-issue はボード上の ProjectV2 item ではないので item_id を持たない。
+            // 代わりに content_id を流用しておく (ナビゲーション用途では未使用)。
+            item_id: issue.id.clone(),
+            content_id: Some(issue.id.clone()),
+            title: issue.title.clone(),
+            number: Some(issue.number as i32),
+            card_type: CardType::Issue { state },
+            assignees,
+            labels,
+            url: Some(issue.url.clone()),
+            body: Some(issue.body.clone()),
+            comments,
+            milestone: issue.milestone.as_ref().map(|m| m.title.clone()),
+            custom_fields: Vec::new(),
+            pr_status: None,
+            linked_prs: Vec::new(),
+            reactions,
+            archived: false,
+            parent_issue: issue.parent.as_ref().map(|p| ParentIssueRef {
+                id: p.id.clone(),
+                number: p.number as i32,
+                title: p.title.clone(),
+                url: Some(p.url.clone()),
+            }),
+            sub_issues_summary: Some(SubIssuesSummary {
+                completed: issue.sub_issues_summary.completed as i32,
+                total: issue.sub_issues_summary.total as i32,
+            }),
+            sub_issues: Vec::new(),
+        })
+    }
+
+    pub async fn fetch_sub_issues(&self, content_id: &str) -> anyhow::Result<Vec<SubIssueRef>> {
+        let vars = fetch_sub_issues::Variables {
+            id: content_id.to_string(),
+        };
+        let data = self.query::<FetchSubIssues>(vars).await?;
+        let node = data.node.context("Node not found")?;
+        let mut sub_issues = Vec::new();
+        if let fetch_sub_issues::FetchSubIssuesNode::Issue(issue) = node
+            && let Some(nodes) = issue.sub_issues.nodes
+        {
+            for n in nodes.into_iter().flatten() {
+                let state = match n.state {
+                    fetch_sub_issues::IssueState::CLOSED => IssueState::Closed,
+                    _ => IssueState::Open,
+                };
+                sub_issues.push(SubIssueRef {
+                    id: n.id,
+                    number: n.number as i32,
+                    title: n.title,
+                    state,
+                    url: Some(n.url),
+                });
+            }
+        }
+        Ok(sub_issues)
+    }
+
     pub async fn add_comment(
         &self,
         subject_id: &str,
@@ -1392,6 +1539,17 @@ fn convert_item(item: &ItemNode) -> Card {
         Some(Content::Issue(issue)) => Card {
             pr_status: None,
             linked_prs: build_linked_prs(issue),
+            parent_issue: issue.parent.as_ref().map(|p| ParentIssueRef {
+                id: p.id.clone(),
+                number: p.number as i32,
+                title: p.title.clone(),
+                url: Some(p.url.clone()),
+            }),
+            sub_issues_summary: Some(SubIssuesSummary {
+                completed: issue.sub_issues_summary.completed as i32,
+                total: issue.sub_issues_summary.total as i32,
+            }),
+            sub_issues: Vec::new(),
             item_id: item.id.clone(),
             archived: item.is_archived,
             content_id: Some(issue.id.clone()),
@@ -1482,6 +1640,9 @@ fn convert_item(item: &ItemNode) -> Card {
         Some(Content::PullRequest(pr)) => Card {
             pr_status: Some(build_pr_status(pr)),
             linked_prs: Vec::new(),
+            parent_issue: None,
+            sub_issues_summary: None,
+            sub_issues: Vec::new(),
             item_id: item.id.clone(),
             archived: item.is_archived,
             content_id: Some(pr.id.clone()),
@@ -1573,6 +1734,9 @@ fn convert_item(item: &ItemNode) -> Card {
         Some(Content::DraftIssue(draft)) => Card {
             pr_status: None,
             linked_prs: Vec::new(),
+            parent_issue: None,
+            sub_issues_summary: None,
+            sub_issues: Vec::new(),
             item_id: item.id.clone(),
             archived: item.is_archived,
             content_id: Some(draft.id.clone()),
@@ -1591,6 +1755,9 @@ fn convert_item(item: &ItemNode) -> Card {
         None => Card {
             pr_status: None,
             linked_prs: Vec::new(),
+            parent_issue: None,
+            sub_issues_summary: None,
+            sub_issues: Vec::new(),
             item_id: item.id.clone(),
             archived: item.is_archived,
             content_id: None,

--- a/src/github/graphql/fetch_issue.graphql
+++ b/src/github/graphql/fetch_issue.graphql
@@ -1,0 +1,44 @@
+query FetchIssue($id: ID!) {
+  node(id: $id) {
+    __typename
+    ... on Issue {
+      id
+      number
+      title
+      state
+      url
+      body
+      milestone { title }
+      assignees(first: 5) { nodes { login } }
+      labels(first: 10) { nodes { id name color } }
+      reactionGroups {
+        content
+        viewerHasReacted
+        reactors { totalCount }
+      }
+      comments(first: 20) {
+        nodes {
+          id
+          author { __typename login }
+          body
+          createdAt
+          reactionGroups {
+            content
+            viewerHasReacted
+            reactors { totalCount }
+          }
+        }
+      }
+      parent {
+        id
+        number
+        title
+        url
+      }
+      subIssuesSummary {
+        completed
+        total
+      }
+    }
+  }
+}

--- a/src/github/graphql/fetch_sub_issues.graphql
+++ b/src/github/graphql/fetch_sub_issues.graphql
@@ -1,0 +1,16 @@
+query FetchSubIssues($id: ID!) {
+  node(id: $id) {
+    __typename
+    ... on Issue {
+      subIssues(first: 50) {
+        nodes {
+          id
+          number
+          title
+          url
+          state
+        }
+      }
+    }
+  }
+}

--- a/src/github/graphql/project_board.graphql
+++ b/src/github/graphql/project_board.graphql
@@ -124,6 +124,16 @@ query ProjectBoard($projectId: ID!, $itemsCursor: String, $query: String) {
                   state
                 }
               }
+              parent {
+                id
+                number
+                title
+                url
+              }
+              subIssuesSummary {
+                completed
+                total
+              }
             }
             ... on PullRequest {
               id

--- a/src/github/queries.rs
+++ b/src/github/queries.rs
@@ -192,6 +192,22 @@ pub struct FetchComments;
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "schema.graphql",
+    query_path = "src/github/graphql/fetch_sub_issues.graphql",
+    response_derives = "Debug"
+)]
+pub struct FetchSubIssues;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "schema.graphql",
+    query_path = "src/github/graphql/fetch_issue.graphql",
+    response_derives = "Debug"
+)]
+pub struct FetchIssue;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "schema.graphql",
     query_path = "src/github/graphql/add_comment.graphql",
     response_derives = "Debug"
 )]

--- a/src/model/project.rs
+++ b/src/model/project.rs
@@ -83,6 +83,32 @@ pub struct Card {
     pub linked_prs: Vec<LinkedPr>,
     pub reactions: Vec<ReactionSummary>,
     pub archived: bool,
+    pub parent_issue: Option<ParentIssueRef>,
+    pub sub_issues_summary: Option<SubIssuesSummary>,
+    pub sub_issues: Vec<SubIssueRef>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ParentIssueRef {
+    pub id: String,
+    pub number: i32,
+    pub title: String,
+    pub url: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct SubIssueRef {
+    pub id: String,
+    pub number: i32,
+    pub title: String,
+    pub state: IssueState,
+    pub url: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct SubIssuesSummary {
+    pub completed: i32,
+    pub total: i32,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/src/model/state.rs
+++ b/src/model/state.rs
@@ -35,6 +35,20 @@ pub const SIDEBAR_ASSIGNEES: usize = 1;
 pub const SIDEBAR_LABELS: usize = 2;
 pub const SIDEBAR_MILESTONE: usize = 3;
 
+/// 詳細ビューサイドバーの論理セクション。
+/// インデックスは `AppState::sidebar_sections()` で動的に解決される。
+#[derive(Clone, Debug, PartialEq)]
+pub enum SidebarSection {
+    Status,
+    Assignees,
+    Labels,
+    Milestone,
+    CustomField(usize),
+    Parent,
+    SubIssue(usize),
+    Archive,
+}
+
 #[derive(Clone, Debug)]
 pub enum SidebarEditMode {
     Labels {

--- a/src/ui/card.rs
+++ b/src/ui/card.rs
@@ -70,6 +70,23 @@ impl Widget for CardWidget<'_> {
             number_str,
             Style::default().add_modifier(Modifier::DIM),
         ));
+        if self.card.parent_issue.is_some() {
+            title_spans.push(Span::styled(
+                "↳ ",
+                Style::default().fg(theme().text_dim),
+            ));
+        }
+        if let Some(summary) = &self.card.sub_issues_summary
+            && summary.total > 0
+        {
+            let text = format!("[{}/{}] ", summary.completed, summary.total);
+            let color = if summary.completed >= summary.total {
+                theme().green
+            } else {
+                theme().blue
+            };
+            title_spans.push(Span::styled(text, Style::default().fg(color)));
+        }
         title_spans.push(Span::raw(&self.card.title));
         if let Some(milestone) = &self.card.milestone {
             title_spans.push(Span::styled(

--- a/src/ui/detail.rs
+++ b/src/ui/detail.rs
@@ -16,7 +16,8 @@ use crate::model::project::{
     ReviewDecision,
 };
 use crate::model::state::{
-    DetailPane, SIDEBAR_ASSIGNEES, SIDEBAR_LABELS, SIDEBAR_MILESTONE, SIDEBAR_STATUS,
+    DetailPane, SidebarSection, SIDEBAR_ASSIGNEES, SIDEBAR_LABELS, SIDEBAR_MILESTONE,
+    SIDEBAR_STATUS,
 };
 use crate::ui::card::parse_hex_color;
 use crate::ui::scroll_fade::{draw_bottom_arrow, draw_left_arrow, draw_right_arrow, draw_top_arrow};
@@ -29,7 +30,7 @@ struct TaggedLine {
 }
 
 pub fn render(frame: &mut Frame, area: Rect, app: &App) {
-    let card = match app.state.selected_card_ref() {
+    let card = match app.state.current_detail_card() {
         Some(c) => c,
         None => return,
     };
@@ -418,7 +419,7 @@ fn render_content_pane(
 
 /// 右ペイン: サイドバー (Status, Assignees, Labels, Archive)
 fn render_sidebar(frame: &mut Frame, area: Rect, app: &App) {
-    let card = match app.state.selected_card_ref() {
+    let card = match app.state.current_detail_card() {
         Some(c) => c,
         None => return,
     };
@@ -438,7 +439,16 @@ fn render_sidebar(frame: &mut Frame, area: Rect, app: &App) {
     let dim_style = Style::default().fg(theme().text_muted);
     let selected_marker = if focused { "▶ " } else { "  " };
 
+    let sections_layout = app.state.sidebar_sections();
+    let mut section_line_offsets: Vec<u16> = vec![0; sections_layout.len()];
     let mut lines: Vec<Line<'static>> = Vec::new();
+    let record = |idx_opt: Option<usize>, offsets: &mut [u16], lines_len: usize| {
+        if let Some(i) = idx_opt
+            && i < offsets.len()
+        {
+            offsets[i] = lines_len as u16;
+        }
+    };
 
     // ── Status section ──
     let status_header_style = if focused && selected == SIDEBAR_STATUS {
@@ -448,6 +458,13 @@ fn render_sidebar(frame: &mut Frame, area: Rect, app: &App) {
     } else {
         header_style
     };
+    record(
+        sections_layout
+            .iter()
+            .position(|s| matches!(s, SidebarSection::Status)),
+        &mut section_line_offsets,
+        lines.len(),
+    );
     lines.push(Line::from(Span::styled("Status", status_header_style)));
 
     let board = app.state.board.as_ref();
@@ -522,6 +539,13 @@ fn render_sidebar(frame: &mut Frame, area: Rect, app: &App) {
     } else {
         header_style
     };
+    record(
+        sections_layout
+            .iter()
+            .position(|s| matches!(s, SidebarSection::Assignees)),
+        &mut section_line_offsets,
+        lines.len(),
+    );
     lines.push(Line::from(Span::styled("Assignees", assignee_header_style)));
     if card.assignees.is_empty() {
         lines.push(Line::from(Span::styled("  --", dim_style)));
@@ -543,6 +567,13 @@ fn render_sidebar(frame: &mut Frame, area: Rect, app: &App) {
     } else {
         header_style
     };
+    record(
+        sections_layout
+            .iter()
+            .position(|s| matches!(s, SidebarSection::Labels)),
+        &mut section_line_offsets,
+        lines.len(),
+    );
     lines.push(Line::from(Span::styled("Labels", label_header_style)));
     if card.labels.is_empty() {
         lines.push(Line::from(Span::styled("  --", dim_style)));
@@ -568,6 +599,13 @@ fn render_sidebar(frame: &mut Frame, area: Rect, app: &App) {
     } else {
         header_style
     };
+    record(
+        sections_layout
+            .iter()
+            .position(|s| matches!(s, SidebarSection::Milestone)),
+        &mut section_line_offsets,
+        lines.len(),
+    );
     lines.push(Line::from(Span::styled("Milestone", milestone_header_style)));
     let milestone_text = card
         .milestone
@@ -591,6 +629,7 @@ fn render_sidebar(frame: &mut Frame, area: Rect, app: &App) {
     }
 
     // ── Custom fields sections ──
+    let sections = &sections_layout;
     let field_defs = app
         .state
         .board
@@ -598,7 +637,10 @@ fn render_sidebar(frame: &mut Frame, area: Rect, app: &App) {
         .map(|b| b.field_definitions.as_slice())
         .unwrap_or(&[]);
     for (i, field) in field_defs.iter().enumerate() {
-        let sidebar_idx = 4 + i;
+        let sidebar_idx = sections
+            .iter()
+            .position(|s| matches!(s, SidebarSection::CustomField(j) if *j == i))
+            .unwrap_or(0);
         let header = if focused && selected == sidebar_idx {
             Style::default()
                 .fg(theme().accent)
@@ -606,6 +648,7 @@ fn render_sidebar(frame: &mut Frame, area: Rect, app: &App) {
         } else {
             header_style
         };
+        record(Some(sidebar_idx), &mut section_line_offsets, lines.len());
         lines.push(Line::from(Span::styled(field.name().to_string(), header)));
         let current = card
             .custom_fields
@@ -613,6 +656,81 @@ fn render_sidebar(frame: &mut Frame, area: Rect, app: &App) {
             .find(|v| v.field_id() == field.id());
         lines.push(render_custom_field_value_line(current));
         lines.push(Line::from(""));
+    }
+
+    // ── Parent / Sub-issues sections (Issue only) ──
+    if matches!(card.card_type, CardType::Issue { .. }) {
+        if let Some(parent) = &card.parent_issue {
+            let parent_idx = sections
+                .iter()
+                .position(|s| matches!(s, SidebarSection::Parent));
+            let focused_here = focused && parent_idx == Some(selected);
+            let header_s = if focused_here {
+                Style::default()
+                    .fg(theme().accent)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                header_style
+            };
+            record(parent_idx, &mut section_line_offsets, lines.len());
+            lines.push(Line::from(Span::styled("Parent", header_s)));
+            let marker = if focused_here { selected_marker } else { "  " };
+            let title_color = if focused_here {
+                theme().accent
+            } else {
+                theme().text
+            };
+            lines.push(Line::from(vec![
+                Span::raw(marker.to_string()),
+                Span::styled(
+                    format!("#{} ", parent.number),
+                    Style::default().add_modifier(Modifier::DIM),
+                ),
+                Span::styled(parent.title.clone(), Style::default().fg(title_color)),
+            ]));
+            lines.push(Line::from(""));
+        }
+
+        if let Some(summary) = &card.sub_issues_summary
+            && summary.total > 0
+        {
+            let header_text = format!("Sub-issues [{}/{}]", summary.completed, summary.total);
+            lines.push(Line::from(Span::styled(header_text, header_style)));
+            if card.sub_issues.is_empty() {
+                lines.push(Line::from(Span::styled(
+                    "  ...".to_string(),
+                    dim_style,
+                )));
+            } else {
+                for (i, sub) in card.sub_issues.iter().enumerate() {
+                    let idx_in_sections = sections
+                        .iter()
+                        .position(|s| matches!(s, SidebarSection::SubIssue(j) if *j == i));
+                    let focused_here = focused && idx_in_sections == Some(selected);
+                    let marker = if focused_here { selected_marker } else { "  " };
+                    let (glyph, color) = match sub.state {
+                        IssueState::Open => ("\u{f41b} ", theme().green),
+                        IssueState::Closed => ("\u{f41d} ", theme().purple),
+                    };
+                    let title_color = if focused_here {
+                        theme().accent
+                    } else {
+                        theme().text
+                    };
+                    record(idx_in_sections, &mut section_line_offsets, lines.len());
+                    lines.push(Line::from(vec![
+                        Span::raw(marker.to_string()),
+                        Span::styled(glyph.to_string(), Style::default().fg(color)),
+                        Span::styled(
+                            format!("#{} ", sub.number),
+                            Style::default().add_modifier(Modifier::DIM),
+                        ),
+                        Span::styled(sub.title.clone(), Style::default().fg(title_color)),
+                    ]));
+                }
+            }
+            lines.push(Line::from(""));
+        }
     }
 
     let block = Block::default().padding(Padding::horizontal(1));
@@ -638,6 +756,7 @@ fn render_sidebar(frame: &mut Frame, area: Rect, app: &App) {
     let pad_total = btn_width.saturating_sub(label.len());
     let pad_left = pad_total / 2;
     let pad_right = pad_total - pad_left;
+    record(Some(archive_idx), &mut section_line_offsets, lines.len());
     lines.push(Line::from(Span::styled(
         "▄".repeat(btn_width),
         edge_style,
@@ -651,8 +770,27 @@ fn render_sidebar(frame: &mut Frame, area: Rect, app: &App) {
         edge_style,
     )));
 
+    // 選択セクションが可視範囲に入るようスクロール位置を計算
+    let total_lines = lines.len() as u16;
+    let visible = inner.height;
+    let max_scroll = total_lines.saturating_sub(visible);
+    let scroll = if focused && selected < section_line_offsets.len() {
+        let target = section_line_offsets[selected];
+        let section_end = if selected + 1 < section_line_offsets.len() {
+            section_line_offsets[selected + 1]
+        } else {
+            total_lines
+        };
+        // 選択セクション全体 (可能な限り) を可視化。
+        let desired_top = target.saturating_sub(1);
+        let desired_bottom = section_end.saturating_sub(visible);
+        desired_top.max(desired_bottom).min(max_scroll)
+    } else {
+        0
+    };
+
     frame.render_widget(block, area);
-    frame.render_widget(Paragraph::new(lines), inner);
+    frame.render_widget(Paragraph::new(lines).scroll((scroll, 0)), inner);
 }
 
 /// サイドバー編集モードのトグルリスト描画
@@ -1385,6 +1523,9 @@ mod tests {
             linked_prs: vec![],
             reactions: vec![],
             archived: false,
+            parent_issue: None,
+            sub_issues_summary: None,
+            sub_issues: vec![],
         }
     }
 
@@ -1406,6 +1547,9 @@ mod tests {
             linked_prs: linked,
             reactions: vec![],
             archived: false,
+            parent_issue: None,
+            sub_issues_summary: None,
+            sub_issues: vec![],
         }
     }
 


### PR DESCRIPTION
## Summary
- Issue の親子関係 (`Issue.parent` / `subIssuesSummary` / `subIssues`) をカードと詳細ビューで可視化
- カード: 親があれば `↳`、sub-issue 進捗があれば `[n/m]` バッジ (完了=green, 進行中=blue)
- 詳細ビュー サイドバー (Custom fields の後、Archive の前) に Parent / Sub-issues セクションを表示
- サイドバーを `SidebarSection` enum で動的レイアウト化し、Parent / SubIssue(i) を j/k で選択可能
- 表示領域を超える場合は選択セクションが可視範囲に入るよう自動スクロール
- Parent / Sub-issue で Enter → `FetchIssueDetail` で Issue を取得し `detail_stack: Vec<Card>` に push してモーダル積み上げ表示 (Esc/q で 1 段戻る)
- スタック上の Issue はボード外なので編集系 (Status/Labels/Archive/CustomField) を無効化

## Test plan
- [x] `cargo test` 303 件パス
- [x] `cargo clippy --all-targets -- -D warnings` 警告なし
- [x] 手動: 親を持つ Issue カードに `↳` が表示されるか
- [x] 手動: sub-issue を持つ Issue カードに `[n/m]` が表示されるか
- [x] 手動: 詳細ビューのサイドバーで Parent / Sub-issue を j/k で選択できるか
- [x] 手動: Sub-issue が多いときサイドバーが自動スクロールするか
- [x] 手動: Enter で sub-issue の詳細モーダルが開き、Esc で戻るか
- [x] 手動: スタック上 Issue でステータス/ラベル編集が無効化されているか
- [x] 手動: DraftIssue / PR / sub-issue を持たない Issue で表示が崩れないか

🤖 Generated with [Claude Code](https://claude.com/claude-code)