### PR TITLE
Add Roadmap view layout for Iteration fields (closes #28)

### DIFF
--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -57,13 +57,15 @@ pub struct AppState {
     pub scroll_offset: usize,
     pub board_scroll_x: std::cell::Cell<usize>,
 
-    // Layout (Board / Table)
+    // Layout (Board / Table / Roadmap)
     pub current_layout: LayoutMode,
     pub table_selected_row: usize,
     /// Table view 用の表示順。Board.columns を平坦化したものをデフォルトとし、
     /// Table での grab 並び替えはこのリストの順序を入れ替える (status は変えない)。
     /// 含まれない item_id は表示時にリスト末尾に付加される。
     pub table_item_order: Vec<String>,
+    /// Roadmap view 用の選択行。`roadmap_rows()` のインデックス。
+    pub roadmap_selected_row: usize,
 
     // Project selection
     pub projects: Vec<ProjectSummary>,
@@ -157,6 +159,7 @@ impl AppState {
             current_layout: LayoutMode::Board,
             table_selected_row: 0,
             table_item_order: Vec::new(),
+            roadmap_selected_row: 0,
             projects: Vec::new(),
             selected_project_index: 0,
             current_project: None,
@@ -200,17 +203,31 @@ impl AppState {
         self.views = views;
     }
 
-    /// Board ↔ Table の表示レイアウトをトグルする。
-    /// 切替時に既存の選択 (Board 側 selected_column/selected_card と Table 側
-    /// table_selected_row) を双方向に同期し、ユーザーが見ていたカードを保つ。
+    /// Board / Table / Roadmap の表示レイアウトを cycle でトグルする。
+    /// Board → Table → Roadmap → Board の順で循環。
+    /// Iteration field が無い project では Roadmap を skip する。
+    /// 切替時に選択状態を双方向に同期し、ユーザーが見ていたカードを保つ。
     pub fn toggle_layout(&mut self) {
+        let has_iter = self
+            .board
+            .as_ref()
+            .is_some_and(|b| b.has_iteration_field());
         match self.current_layout {
             LayoutMode::Board => {
                 self.table_selected_row = self.current_table_row();
                 self.current_layout = LayoutMode::Table;
             }
             LayoutMode::Table => {
-                self.set_selection_from_table_row(self.table_selected_row);
+                if has_iter {
+                    self.roadmap_selected_row = self.table_selected_row;
+                    self.current_layout = LayoutMode::Roadmap;
+                } else {
+                    self.set_selection_from_table_row(self.table_selected_row);
+                    self.current_layout = LayoutMode::Board;
+                }
+            }
+            LayoutMode::Roadmap => {
+                self.set_selection_from_roadmap_row(self.roadmap_selected_row);
                 self.current_layout = LayoutMode::Board;
             }
         }
@@ -244,9 +261,11 @@ impl AppState {
         self.scroll_offset = 0;
         self.current_layout = match self.views[idx].layout {
             Some(LayoutModeConfig::Table) => LayoutMode::Table,
+            Some(LayoutModeConfig::Roadmap) => LayoutMode::Roadmap,
             _ => LayoutMode::Board,
         };
         self.table_selected_row = 0;
+        self.roadmap_selected_row = 0;
         if let Some(project) = &self.current_project {
             let id = project.id.clone();
             self.start_loading_board(&id)
@@ -264,6 +283,7 @@ impl AppState {
         self.scroll_offset = 0;
         self.current_layout = LayoutMode::Board;
         self.table_selected_row = 0;
+        self.roadmap_selected_row = 0;
         if let Some(project) = &self.current_project {
             let id = project.id.clone();
             self.start_loading_board(&id)
@@ -781,6 +801,9 @@ impl AppState {
         if self.current_layout == LayoutMode::Table {
             return self.handle_table_key(key);
         }
+        if self.current_layout == LayoutMode::Roadmap {
+            return self.handle_roadmap_key(key);
+        }
 
         let board = match &self.board {
             Some(b) => b,
@@ -1065,6 +1088,128 @@ impl AppState {
                     });
                     self.mode = ViewMode::CardGrab;
                 }
+                Command::None
+            }
+            _ => Command::None,
+        }
+    }
+
+    /// Roadmap layout のキーハンドラ。
+    /// 行ベース (roadmap_selected_row) でナビゲーションし、Detail/Archive 等の遷移時は
+    /// `set_selection_from_roadmap_row` で Board 用の (selected_column, selected_card) を
+    /// 書き戻してから既存ロジックを再利用する。
+    /// Iteration / Date の期間編集は MVP スコープ外のため Space / h / l は no-op。
+    fn handle_roadmap_key(&mut self, key: KeyEvent) -> Command {
+        let board = match &self.board {
+            Some(b) => b,
+            None => return Command::None,
+        };
+
+        if board.columns.is_empty() {
+            match self.keymap.resolve(KeymapMode::Roadmap, &key) {
+                Some(Action::Quit) | Some(Action::ForceQuit) => self.should_quit = true,
+                Some(Action::SwitchProject) => return self.enter_project_select(),
+                Some(Action::ShowHelp) => self.mode = ViewMode::Help,
+                Some(Action::ToggleLayout) => self.toggle_layout(),
+                _ => {}
+            }
+            return Command::None;
+        }
+
+        // View switching (1-9, 0) は Board と同じ
+        if let KeyCode::Char(c @ '1'..='9') = key.code
+            && key.modifiers == KeyModifiers::NONE
+        {
+            return self.switch_to_view((c as usize) - ('1' as usize));
+        }
+        if key.code == KeyCode::Char('0') && key.modifiers == KeyModifiers::NONE {
+            return self.clear_view();
+        }
+
+        let action = match self.keymap.resolve(KeymapMode::Roadmap, &key) {
+            Some(a) => a,
+            None => return Command::None,
+        };
+
+        let row_count = self.roadmap_rows().len();
+
+        match action {
+            Action::Quit | Action::ForceQuit => {
+                self.should_quit = true;
+                Command::None
+            }
+            Action::MoveDown => {
+                if row_count > 0 {
+                    self.roadmap_selected_row =
+                        (self.roadmap_selected_row + 1).min(row_count - 1);
+                }
+                Command::None
+            }
+            Action::MoveUp => {
+                self.roadmap_selected_row = self.roadmap_selected_row.saturating_sub(1);
+                Command::None
+            }
+            Action::FirstItem => {
+                self.roadmap_selected_row = 0;
+                Command::None
+            }
+            Action::LastItem => {
+                if row_count > 0 {
+                    self.roadmap_selected_row = row_count - 1;
+                }
+                Command::None
+            }
+            Action::OpenDetail => {
+                self.set_selection_from_roadmap_row(self.roadmap_selected_row);
+                self.open_detail_view()
+            }
+            Action::SwitchProject => self.enter_project_select(),
+            Action::Refresh => {
+                if let Some(project) = &self.current_project {
+                    let id = project.id.clone();
+                    self.start_loading_board(&id)
+                } else {
+                    Command::None
+                }
+            }
+            Action::ShowHelp => {
+                self.mode = ViewMode::Help;
+                Command::None
+            }
+            Action::ChangeGrouping => {
+                self.open_group_by_select();
+                Command::None
+            }
+            Action::ToggleLayout => {
+                self.toggle_layout();
+                Command::None
+            }
+            Action::StartFilter => {
+                self.filter.input.clear();
+                self.filter.cursor_pos = 0;
+                self.mode = ViewMode::Filter;
+                Command::None
+            }
+            Action::ClearFilter => {
+                self.active_view = None;
+                self.filter.active_filter = None;
+                self.roadmap_selected_row = 0;
+                if let Some(project) = &self.current_project {
+                    let id = project.id.clone();
+                    self.start_loading_board(&id)
+                } else {
+                    Command::None
+                }
+            }
+            Action::ArchiveCard => {
+                self.set_selection_from_roadmap_row(self.roadmap_selected_row);
+                self.start_archive_card(ViewMode::Board);
+                Command::None
+            }
+            Action::ShowArchivedList => self.show_archived_list(),
+            Action::NewCard => {
+                self.create_card_state = CreateCardState::default();
+                self.mode = ViewMode::CreateCard;
                 Command::None
             }
             _ => Command::None,
@@ -2327,6 +2472,44 @@ impl AppState {
     /// (selected_column, selected_card) に書き戻す。
     pub fn set_selection_from_table_row(&mut self, row: usize) {
         let rows = self.table_rows();
+        if let Some(&(col, real_idx)) = rows.get(row) {
+            self.selected_column = col;
+            let display_idx = self
+                .filtered_card_indices(col)
+                .iter()
+                .position(|&i| i == real_idx)
+                .unwrap_or(0);
+            self.selected_card = display_idx;
+        }
+    }
+
+    /// Roadmap view の表示順 `(col_idx, real_card_idx)` を返す。
+    /// MVP では `table_rows()` と同じ順序を利用する (column-major flatten + filter 適用)。
+    /// 各 row は 1 カードに対応し、iteration が未設定のカードも含まれる (render 側で bar を省略)。
+    pub fn roadmap_rows(&self) -> Vec<(usize, usize)> {
+        self.table_rows()
+    }
+
+    /// Board → Roadmap 切替時に、現在の (selected_column, selected_card) を
+    /// roadmap_selected_row に変換する。
+    /// 現状 `roadmap_rows()` は `table_rows()` と同一順序のため `current_table_row()`
+    /// と等価。将来 roadmap 独自の並び順を導入したときに差別化する。
+    #[allow(dead_code)]
+    pub fn current_roadmap_row(&self) -> usize {
+        let real = match self.real_card_index() {
+            Some(r) => r,
+            None => return 0,
+        };
+        self.roadmap_rows()
+            .iter()
+            .position(|&(col, idx)| col == self.selected_column && idx == real)
+            .unwrap_or(0)
+    }
+
+    /// Roadmap → Board 切替時に、roadmap_selected_row を
+    /// (selected_column, selected_card) に書き戻す。
+    pub fn set_selection_from_roadmap_row(&mut self, row: usize) {
+        let rows = self.roadmap_rows();
         if let Some(&(col, real_idx)) = rows.get(row) {
             self.selected_column = col;
             let display_idx = self
@@ -8191,11 +8374,15 @@ mod tests {
                     id: "it_1".into(),
                     title: "Sprint 1".into(),
                     start_date: "2026-04-01".into(),
+                    duration: 14,
+                    completed: false,
                 },
                 IterationOption {
                     id: "it_2".into(),
                     title: "Sprint 2".into(),
                     start_date: "2026-04-15".into(),
+                    duration: 14,
+                    completed: false,
                 },
             ],
         }
@@ -8590,11 +8777,15 @@ mod tests {
                             id: "it_1".into(),
                             title: "Sprint 1".into(),
                             start_date: "2026-04-01".into(),
+                            duration: 14,
+                            completed: false,
                         },
                         IterationOption {
                             id: "it_2".into(),
                             title: "Sprint 2".into(),
                             start_date: "2026-04-15".into(),
+                            duration: 14,
+                            completed: false,
                         },
                     ],
                 },
@@ -8926,8 +9117,79 @@ mod tests {
         assert_eq!(state.current_layout, LayoutMode::Board);
         state.handle_event(AppEvent::Key(key(KeyCode::Char('t'))));
         assert_eq!(state.current_layout, LayoutMode::Table);
+        // Iteration field が無いので Roadmap は skip し Board に戻る
         state.handle_event(AppEvent::Key(key(KeyCode::Char('t'))));
         assert_eq!(state.current_layout, LayoutMode::Board);
+    }
+
+    #[test]
+    fn test_toggle_layout_three_way_cycle_with_iteration_field() {
+        use crate::model::project::{FieldDefinition, IterationOption};
+        let board = make_board_with_fields(
+            vec![(
+                "Todo",
+                "opt_1",
+                vec![make_card("1", "A")],
+            )],
+            vec![FieldDefinition::Iteration {
+                id: "fld_it".into(),
+                name: "Iteration".into(),
+                iterations: vec![IterationOption {
+                    id: "it_1".into(),
+                    title: "Sprint 1".into(),
+                    start_date: "2026-04-01".into(),
+                    duration: 14,
+                    completed: false,
+                }],
+            }],
+        );
+        let mut state = make_state_with_board(board);
+
+        assert_eq!(state.current_layout, LayoutMode::Board);
+        state.handle_event(AppEvent::Key(key(KeyCode::Char('t'))));
+        assert_eq!(state.current_layout, LayoutMode::Table);
+        state.handle_event(AppEvent::Key(key(KeyCode::Char('t'))));
+        assert_eq!(state.current_layout, LayoutMode::Roadmap);
+        state.handle_event(AppEvent::Key(key(KeyCode::Char('t'))));
+        assert_eq!(state.current_layout, LayoutMode::Board);
+    }
+
+    #[test]
+    fn test_roadmap_move_down_and_back_to_board() {
+        use crate::model::project::{FieldDefinition, IterationOption};
+        let board = make_board_with_fields(
+            vec![(
+                "Todo",
+                "opt_1",
+                vec![make_card("1", "A"), make_card("2", "B")],
+            )],
+            vec![FieldDefinition::Iteration {
+                id: "fld_it".into(),
+                name: "Iteration".into(),
+                iterations: vec![IterationOption {
+                    id: "it_1".into(),
+                    title: "Sprint 1".into(),
+                    start_date: "2026-04-01".into(),
+                    duration: 14,
+                    completed: false,
+                }],
+            }],
+        );
+        let mut state = make_state_with_board(board);
+        state.current_layout = LayoutMode::Roadmap;
+
+        state.handle_event(AppEvent::Key(key(KeyCode::Char('j'))));
+        assert_eq!(state.roadmap_selected_row, 1);
+        state.handle_event(AppEvent::Key(key(KeyCode::Char('j'))));
+        assert_eq!(state.roadmap_selected_row, 1); // 末尾でクランプ
+        state.handle_event(AppEvent::Key(key(KeyCode::Char('k'))));
+        assert_eq!(state.roadmap_selected_row, 0);
+
+        // Roadmap → Board で選択が同期される
+        state.roadmap_selected_row = 1;
+        state.handle_event(AppEvent::Key(key(KeyCode::Char('t'))));
+        assert_eq!(state.current_layout, LayoutMode::Board);
+        assert_eq!(state.selected_card, 1);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,7 @@ use serde::Deserialize;
 pub enum LayoutModeConfig {
     Board,
     Table,
+    Roadmap,
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
@@ -423,6 +424,17 @@ layout = "board"
 "#;
         let config: Config = toml::from_str(toml).unwrap();
         assert_eq!(config.view[0].layout, Some(LayoutModeConfig::Board));
+    }
+
+    #[test]
+    fn test_parse_view_with_layout_roadmap() {
+        let toml = r#"
+[[view]]
+name = "Sprint"
+layout = "roadmap"
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert_eq!(config.view[0].layout, Some(LayoutModeConfig::Roadmap));
     }
 
     #[test]

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -1127,7 +1127,18 @@ fn build_board(
                 field_definitions.push(def);
             }
             FieldNodes::ProjectV2IterationField(f) => {
-                let iterations = f
+                let completed = f
+                    .configuration
+                    .completed_iterations
+                    .into_iter()
+                    .map(|it| IterationOption {
+                        id: it.id,
+                        title: it.title,
+                        start_date: it.start_date,
+                        duration: it.duration as i32,
+                        completed: true,
+                    });
+                let upcoming = f
                     .configuration
                     .iterations
                     .into_iter()
@@ -1135,8 +1146,11 @@ fn build_board(
                         id: it.id,
                         title: it.title,
                         start_date: it.start_date,
-                    })
-                    .collect();
+                        duration: it.duration as i32,
+                        completed: false,
+                    });
+                let mut iterations: Vec<IterationOption> = completed.chain(upcoming).collect();
+                iterations.sort_by(|a, b| a.start_date.cmp(&b.start_date));
                 field_definitions.push(FieldDefinition::Iteration {
                     id: f.id,
                     name: f.name,

--- a/src/github/graphql/project_board.graphql
+++ b/src/github/graphql/project_board.graphql
@@ -34,6 +34,13 @@ query ProjectBoard($projectId: ID!, $itemsCursor: String, $query: String) {
                 id
                 title
                 startDate
+                duration
+              }
+              completedIterations {
+                id
+                title
+                startDate
+                duration
               }
             }
           }

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -143,6 +143,7 @@ fn parse_key_name(name: &str) -> Result<KeyCode, String> {
 pub enum KeymapMode {
     Board,
     Table,
+    Roadmap,
     ProjectSelect,
     Help,
     Confirm,
@@ -245,6 +246,29 @@ impl Keymap {
         table.insert(KeyBind::char('q'), Action::Quit);
         table.insert(KeyBind::key(KeyCode::Esc), Action::Quit);
         keymap.modes.insert(KeymapMode::Table, table);
+
+        // Roadmap mode (LayoutMode::Roadmap 時の board ハンドラから利用)
+        let mut roadmap = HashMap::new();
+        roadmap.insert(KeyBind::char('j'), Action::MoveDown);
+        roadmap.insert(KeyBind::key(KeyCode::Down), Action::MoveDown);
+        roadmap.insert(KeyBind::char('k'), Action::MoveUp);
+        roadmap.insert(KeyBind::key(KeyCode::Up), Action::MoveUp);
+        roadmap.insert(KeyBind::char('g'), Action::FirstItem);
+        roadmap.insert(KeyBind::char('G'), Action::LastItem);
+        roadmap.insert(KeyBind::key(KeyCode::Enter), Action::OpenDetail);
+        roadmap.insert(KeyBind::char('p'), Action::SwitchProject);
+        roadmap.insert(KeyBind::char('r'), Action::Refresh);
+        roadmap.insert(KeyBind::char('?'), Action::ShowHelp);
+        roadmap.insert(KeyBind::char('/'), Action::StartFilter);
+        roadmap.insert(KeyBind::ctrl('u'), Action::ClearFilter);
+        roadmap.insert(KeyBind::char('a'), Action::ArchiveCard);
+        roadmap.insert(KeyBind::char('v'), Action::ShowArchivedList);
+        roadmap.insert(KeyBind::char('n'), Action::NewCard);
+        roadmap.insert(KeyBind::ctrl('g'), Action::ChangeGrouping);
+        roadmap.insert(KeyBind::char('t'), Action::ToggleLayout);
+        roadmap.insert(KeyBind::char('q'), Action::Quit);
+        roadmap.insert(KeyBind::key(KeyCode::Esc), Action::Quit);
+        keymap.modes.insert(KeymapMode::Roadmap, roadmap);
 
         // ProjectSelect mode (文字キーはフィルタ入力に使うため割り当てない)
         let mut project_select = HashMap::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -186,6 +186,19 @@ fn render_layout(frame: &mut Frame, area: Rect, app: &App) {
     match app.state.current_layout {
         LayoutMode::Board => ui::board::render(frame, area, app),
         LayoutMode::Table => ui::table::render(frame, area, app),
+        LayoutMode::Roadmap => {
+            // Iteration field が無い project では Board にフォールバックする
+            let has_iter = app
+                .state
+                .board
+                .as_ref()
+                .is_some_and(|b| b.has_iteration_field());
+            if has_iter {
+                ui::roadmap::render(frame, area, app);
+            } else {
+                ui::board::render(frame, area, app);
+            }
+        }
     }
 }
 

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,3 +1,4 @@
 pub mod board_cache;
 pub mod project;
+pub mod roadmap;
 pub mod state;

--- a/src/model/project.rs
+++ b/src/model/project.rs
@@ -45,6 +45,24 @@ impl Grouping {
     }
 }
 
+impl Board {
+    /// Iteration field があれば (field_id, field_name, iterations) を返す。複数ある場合は最初の 1 つ。
+    pub fn iteration_field(&self) -> Option<(&str, &str, &[IterationOption])> {
+        self.field_definitions.iter().find_map(|d| match d {
+            FieldDefinition::Iteration {
+                id,
+                name,
+                iterations,
+            } => Some((id.as_str(), name.as_str(), iterations.as_slice())),
+            _ => None,
+        })
+    }
+
+    pub fn has_iteration_field(&self) -> bool {
+        self.iteration_field().is_some()
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct Column {
     pub option_id: String,
@@ -202,6 +220,8 @@ pub struct IterationOption {
     pub id: String,
     pub title: String,
     pub start_date: String,
+    pub duration: i32,
+    pub completed: bool,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/src/model/roadmap.rs
+++ b/src/model/roadmap.rs
@@ -1,0 +1,283 @@
+//! Roadmap view の時間軸計算 (pure functions)。
+//!
+//! `roadmap_timeline` は iterations と今日の日付から、表示対象ウィンドウ
+//! (今日を含む ±2 iteration) と各セグメントの列幅を決定する。
+
+use crate::model::project::IterationOption;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TimelineSegment {
+    pub iteration_id: String,
+    pub title: String,
+    pub start_date: String,
+    pub duration: i32,
+    pub completed: bool,
+    pub contains_today: bool,
+    pub start_col: u16,
+    pub width: u16,
+}
+
+/// 表示対象 iteration と描画列を計算する。
+///
+/// * `iterations` — 全 iteration (sorted されていなくても良い)
+/// * `today` — 現在日付 (Some(y, m, d)) または None。None なら最初の非完了 iteration を中心にする
+/// * `total_width` — 描画領域の幅 (列数)
+///
+/// 戻り値: 表示対象の iteration 一覧 (start_col, width 付き)。空 iteration / 幅 0 なら空ベクタ。
+pub fn roadmap_timeline(
+    iterations: &[IterationOption],
+    today: Option<(i32, u32, u32)>,
+    total_width: u16,
+) -> Vec<TimelineSegment> {
+    if iterations.is_empty() || total_width == 0 {
+        return Vec::new();
+    }
+
+    let mut sorted_indices: Vec<usize> = (0..iterations.len()).collect();
+    sorted_indices.sort_by(|&a, &b| iterations[a].start_date.cmp(&iterations[b].start_date));
+
+    let starts: Vec<Option<i64>> = iterations
+        .iter()
+        .map(|it| date_to_days(&it.start_date))
+        .collect();
+    let today_days = today.map(|(y, m, d)| days_from_civil(y, m, d));
+
+    // 今日を含む iteration → 今日より後の最初の iteration → 末尾の順でセンターを決定
+    let center = if let Some(td) = today_days {
+        sorted_indices
+            .iter()
+            .position(|&i| {
+                starts[i]
+                    .is_some_and(|s| td >= s && td < s + iterations[i].duration.max(1) as i64)
+            })
+            .or_else(|| {
+                sorted_indices
+                    .iter()
+                    .position(|&i| starts[i].is_some_and(|s| s > td))
+            })
+            .unwrap_or(sorted_indices.len().saturating_sub(1))
+    } else {
+        sorted_indices
+            .iter()
+            .position(|&i| !iterations[i].completed)
+            .unwrap_or(sorted_indices.len().saturating_sub(1))
+    };
+
+    let win_start = center.saturating_sub(2);
+    let win_end = (center + 3).min(sorted_indices.len());
+    let window: Vec<usize> = sorted_indices[win_start..win_end].to_vec();
+
+    let total_duration: i64 = window
+        .iter()
+        .map(|&i| iterations[i].duration.max(1) as i64)
+        .sum();
+    if total_duration <= 0 {
+        return Vec::new();
+    }
+
+    let mut segments = Vec::with_capacity(window.len());
+    let mut cursor: u16 = 0;
+    let last_idx = window.len() - 1;
+    for (n, &i) in window.iter().enumerate() {
+        let it = &iterations[i];
+        let w = if n == last_idx {
+            // 末尾セグメントで端数を吸収
+            total_width.saturating_sub(cursor)
+        } else {
+            let raw = (it.duration.max(1) as i64) * total_width as i64 / total_duration;
+            raw as u16
+        };
+        let contains_today = today_days.is_some_and(|td| {
+            starts[i].is_some_and(|s| td >= s && td < s + it.duration.max(1) as i64)
+        });
+        segments.push(TimelineSegment {
+            iteration_id: it.id.clone(),
+            title: it.title.clone(),
+            start_date: it.start_date.clone(),
+            duration: it.duration,
+            completed: it.completed,
+            contains_today,
+            start_col: cursor,
+            width: w,
+        });
+        cursor = cursor.saturating_add(w);
+    }
+    segments
+}
+
+/// YYYY-MM-DD 形式をパースして (year, month, day) を返す。
+pub fn parse_ymd(s: &str) -> Option<(i32, u32, u32)> {
+    if s.len() != 10 || s.as_bytes()[4] != b'-' || s.as_bytes()[7] != b'-' {
+        return None;
+    }
+    let y: i32 = s[0..4].parse().ok()?;
+    let m: u32 = s[5..7].parse().ok()?;
+    let d: u32 = s[8..10].parse().ok()?;
+    if !(1..=12).contains(&m) || !(1..=31).contains(&d) {
+        return None;
+    }
+    Some((y, m, d))
+}
+
+fn date_to_days(s: &str) -> Option<i64> {
+    let (y, m, d) = parse_ymd(s)?;
+    Some(days_from_civil(y, m, d))
+}
+
+/// Howard Hinnant's proleptic Gregorian "days from civil" algorithm。
+/// 1970-01-01 からの経過日数を返す (epoch より前は負)。
+fn days_from_civil(y: i32, m: u32, d: u32) -> i64 {
+    let y = if m <= 2 { y - 1 } else { y };
+    let era = if y >= 0 { y } else { y - 399 } / 400;
+    let yoe = (y - era * 400) as i64;
+    let m_adj = if m > 2 { m - 3 } else { m + 9 };
+    let doy = (153 * m_adj as i64 + 2) / 5 + d as i64 - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    era as i64 * 146097 + doe - 719468
+}
+
+/// Hinnant's inverse (days since 1970-01-01 → (y, m, d))。
+fn civil_from_days(days: i64) -> (i32, u32, u32) {
+    let days = days + 719468;
+    let era = if days >= 0 { days } else { days - 146096 } / 146097;
+    let doe = (days - era * 146097) as u64;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y_raw = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y_raw + 1 } else { y_raw };
+    (y as i32, m as u32, d as u32)
+}
+
+/// 現在日付 (UTC) を (year, month, day) で返す。システム時刻が取得できない場合は None。
+pub fn today_utc() -> Option<(i32, u32, u32)> {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let elapsed = SystemTime::now().duration_since(UNIX_EPOCH).ok()?;
+    let days = (elapsed.as_secs() / 86400) as i64;
+    Some(civil_from_days(days))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn iteration(id: &str, title: &str, start_date: &str, duration: i32, completed: bool) -> IterationOption {
+        IterationOption {
+            id: id.into(),
+            title: title.into(),
+            start_date: start_date.into(),
+            duration,
+            completed,
+        }
+    }
+
+    #[test]
+    fn empty_iterations_yield_empty_segments() {
+        let out = roadmap_timeline(&[], Some((2026, 4, 16)), 80);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn zero_width_yields_empty_segments() {
+        let its = vec![iteration("it1", "S1", "2026-04-01", 14, false)];
+        let out = roadmap_timeline(&its, Some((2026, 4, 8)), 0);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn window_picks_up_to_5_iterations_around_today() {
+        // 7 iterations (7 日刻み、1 月にまたがらないよう短く)。
+        // start: 01, 08, 15, 22, 29, 06(次月), 13(次月)
+        let its: Vec<IterationOption> = vec![
+            iteration("it0", "S0", "2026-04-01", 7, false),
+            iteration("it1", "S1", "2026-04-08", 7, false),
+            iteration("it2", "S2", "2026-04-15", 7, false),
+            iteration("it3", "S3", "2026-04-22", 7, false),
+            iteration("it4", "S4", "2026-04-29", 7, false),
+            iteration("it5", "S5", "2026-05-06", 7, false),
+            iteration("it6", "S6", "2026-05-13", 7, false),
+        ];
+        // today = 2026-04-17 (it2 の中に含まれる → center=2 → window=[0..5])
+        let out = roadmap_timeline(&its, Some((2026, 4, 17)), 100);
+        assert_eq!(out.len(), 5);
+        assert_eq!(out[0].iteration_id, "it0");
+        assert_eq!(out[4].iteration_id, "it4");
+        assert!(out.iter().any(|s| s.iteration_id == "it2" && s.contains_today));
+    }
+
+    #[test]
+    fn widths_sum_to_total_width() {
+        let its: Vec<IterationOption> = vec![
+            iteration("a", "A", "2026-04-01", 7, false),
+            iteration("b", "B", "2026-04-08", 14, false),
+            iteration("c", "C", "2026-04-22", 7, false),
+        ];
+        let out = roadmap_timeline(&its, Some((2026, 4, 10)), 80);
+        let total: u16 = out.iter().map(|s| s.width).sum();
+        assert_eq!(total, 80);
+    }
+
+    #[test]
+    fn today_before_all_iterations_picks_first() {
+        let its = vec![
+            iteration("a", "A", "2026-05-01", 14, false),
+            iteration("b", "B", "2026-05-15", 14, false),
+        ];
+        let out = roadmap_timeline(&its, Some((2026, 4, 1)), 60);
+        // today は全 iteration より前なので「最初の today 以降」= a を center に
+        assert_eq!(out.first().map(|s| s.iteration_id.as_str()), Some("a"));
+        assert!(!out.iter().any(|s| s.contains_today));
+    }
+
+    #[test]
+    fn today_none_picks_first_non_completed() {
+        let its = vec![
+            iteration("a", "A", "2026-03-01", 14, true),
+            iteration("b", "B", "2026-03-15", 14, true),
+            iteration("c", "C", "2026-03-29", 14, false),
+            iteration("d", "D", "2026-04-12", 14, false),
+        ];
+        let out = roadmap_timeline(&its, None, 60);
+        // non-completed の最初は c (index=2)、window は [0,1,2,3] (center=2, win=[0..4])
+        assert!(out.iter().any(|s| s.iteration_id == "c"));
+    }
+
+    #[test]
+    fn segments_are_contiguous() {
+        let its = vec![
+            iteration("a", "A", "2026-04-01", 7, false),
+            iteration("b", "B", "2026-04-08", 7, false),
+        ];
+        let out = roadmap_timeline(&its, Some((2026, 4, 5)), 40);
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].start_col, 0);
+        assert_eq!(out[1].start_col, out[0].width);
+    }
+
+    #[test]
+    fn days_from_civil_known_values() {
+        assert_eq!(days_from_civil(1970, 1, 1), 0);
+        assert_eq!(days_from_civil(1970, 1, 2), 1);
+        assert_eq!(days_from_civil(1969, 12, 31), -1);
+        // 2020-01-01 = 18262 days since epoch
+        assert_eq!(days_from_civil(2020, 1, 1), 18262);
+    }
+
+    #[test]
+    fn civil_from_days_roundtrip() {
+        for (y, m, d) in [(1970, 1, 1), (2020, 2, 29), (2026, 4, 16), (1999, 12, 31)] {
+            let days = days_from_civil(y, m, d);
+            assert_eq!(civil_from_days(days), (y, m, d), "roundtrip for {y}-{m}-{d}");
+        }
+    }
+
+    #[test]
+    fn parse_ymd_rejects_invalid() {
+        assert!(parse_ymd("2026-13-01").is_none());
+        assert!(parse_ymd("2026-04-32").is_none());
+        assert!(parse_ymd("not-a-date").is_none());
+        assert_eq!(parse_ymd("2026-04-16"), Some((2026, 4, 16)));
+    }
+}

--- a/src/model/state.rs
+++ b/src/model/state.rs
@@ -23,14 +23,15 @@ pub enum ViewMode {
     ArchivedList,
 }
 
-/// Board の表示レイアウト。Kanban (Board) と Table の 2 種類をサポート。
+/// Board の表示レイアウト。Kanban (Board) / Table / Roadmap の 3 種類をサポート。
 /// `ViewMode::Board` のサブモードとして扱い、Detail/Filter/CardGrab 等の既存モーダルは
-/// どちらのレイアウトからも開ける。
+/// どのレイアウトからも開ける。
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub enum LayoutMode {
     #[default]
     Board,
     Table,
+    Roadmap,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -84,7 +84,7 @@ pub fn render(frame: &mut Frame, area: Rect, keymap: &Keymap) {
         HelpEntry { action: Action::OpenDetail, description: "View card detail" },
         HelpEntry { action: Action::SwitchProject, description: "Switch project" },
         HelpEntry { action: Action::ChangeGrouping, description: "Change grouping field" },
-        HelpEntry { action: Action::ToggleLayout, description: "Toggle layout (Board/Table)" },
+        HelpEntry { action: Action::ToggleLayout, description: "Toggle layout (Board/Table/Roadmap)" },
         HelpEntry { action: Action::StartFilter, description: "Filter (label: assignee: milestone: |:OR)" },
         HelpEntry { action: Action::ClearFilter, description: "Clear filter / view" },
         HelpEntry { action: Action::Refresh, description: "Refresh" },

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -12,6 +12,7 @@ pub mod help;
 pub mod project_list;
 pub mod reaction_picker;
 pub mod repo_select;
+pub mod roadmap;
 pub mod scroll_fade;
 pub mod statusline;
 pub mod tab_bar;

--- a/src/ui/roadmap.rs
+++ b/src/ui/roadmap.rs
@@ -1,0 +1,288 @@
+use ratatui::{
+    Frame,
+    layout::{Constraint, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, BorderType, Borders, Cell, Row, Table, TableState},
+};
+use unicode_width::UnicodeWidthChar;
+
+use crate::app::App;
+use crate::model::project::{Card, CardType, CustomFieldValue, IterationOption};
+use crate::model::roadmap::{TimelineSegment, roadmap_timeline, today_utc};
+use crate::ui::theme::theme;
+
+const LEFT_COL_WIDTH: u16 = 40;
+
+pub fn render(frame: &mut Frame, area: Rect, app: &App) {
+    let board = match &app.state.board {
+        Some(b) => b,
+        None => return,
+    };
+    if board.columns.is_empty() {
+        return;
+    }
+    let (iter_field_id, _iter_field_name, iterations) = match board.iteration_field() {
+        Some(x) => x,
+        None => return,
+    };
+
+    let rows_count = app.state.roadmap_rows().len();
+    let title = format!(" {} Roadmap ({}) ", board.project_title, rows_count);
+    let block = Block::default()
+        .title(title)
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(theme().border_focused));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    // Timeline 領域の幅 (左ペイン + 1 スペース + 右ペイン = inner.width)
+    let timeline_width = inner.width.saturating_sub(LEFT_COL_WIDTH + 1);
+    if timeline_width == 0 {
+        return;
+    }
+
+    let today = today_utc();
+    let segments = roadmap_timeline(iterations, today, timeline_width);
+    if segments.is_empty() {
+        return;
+    }
+
+    let iter_field_id = iter_field_id.to_string();
+    let rows_data = app.state.roadmap_rows();
+    let all_iterations: &[IterationOption] = iterations;
+
+    // ヘッダー: 左=Title, 右=iteration 名を start_col/width に配置
+    let header = Row::new(vec![
+        Cell::from(Span::styled(
+            "Title",
+            Style::default()
+                .fg(theme().text_dim)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Cell::from(timeline_header_line(&segments, timeline_width)),
+    ])
+    .height(1);
+
+    // 各カード行
+    let rows: Vec<Row> = rows_data
+        .iter()
+        .map(|&(col_idx, card_idx)| {
+            let card = &board.columns[col_idx].cards[card_idx];
+            let title_cell = Cell::from(card_title_line(card));
+            let timeline_cell = Cell::from(card_timeline_line(
+                card,
+                &iter_field_id,
+                all_iterations,
+                &segments,
+                timeline_width,
+            ));
+            Row::new(vec![title_cell, timeline_cell]).height(1)
+        })
+        .collect();
+
+    let total_rows = rows.len();
+    let constraints = [
+        Constraint::Length(LEFT_COL_WIDTH),
+        Constraint::Min(timeline_width),
+    ];
+
+    let table = Table::new(rows, constraints)
+        .header(header)
+        .row_highlight_style(
+            Style::default()
+                .bg(theme().accent)
+                .fg(theme().text_inverted)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("  ")
+        .column_spacing(1);
+
+    let mut state = TableState::default();
+    let selected = if total_rows == 0 {
+        None
+    } else {
+        Some(app.state.roadmap_selected_row.min(total_rows - 1))
+    };
+    state.select(selected);
+
+    frame.render_stateful_widget(table, inner, &mut state);
+}
+
+fn type_marker(ct: &CardType) -> Span<'static> {
+    match ct {
+        CardType::Issue { .. } => Span::styled("\u{f41b}", Style::default().fg(theme().green)),
+        CardType::PullRequest { .. } => {
+            Span::styled("\u{f407}", Style::default().fg(theme().blue))
+        }
+        CardType::DraftIssue => Span::styled("\u{f404}", Style::default().fg(theme().text_dim)),
+    }
+}
+
+fn card_title_line(card: &Card) -> Line<'_> {
+    let mut spans = vec![type_marker(&card.card_type), Span::raw(" ")];
+    if card.parent_issue.is_some() {
+        spans.push(Span::styled("↳ ", Style::default().fg(theme().text_dim)));
+    }
+    spans.push(Span::raw(card.title.as_str()));
+    Line::from(spans)
+}
+
+fn timeline_header_line<'a>(segments: &'a [TimelineSegment], total_width: u16) -> Line<'a> {
+    let mut spans: Vec<Span<'a>> = Vec::with_capacity(segments.len() * 2);
+    let mut cursor: u16 = 0;
+    for seg in segments {
+        if seg.start_col > cursor {
+            spans.push(Span::raw(" ".repeat((seg.start_col - cursor) as usize)));
+            cursor = seg.start_col;
+        }
+        let w = seg.width as usize;
+        let label = truncate_pad(&seg.title, w);
+        let style = if seg.contains_today {
+            Style::default()
+                .fg(theme().accent)
+                .add_modifier(Modifier::BOLD)
+        } else if seg.completed {
+            Style::default().fg(theme().text_dim)
+        } else {
+            Style::default()
+                .fg(theme().text_muted)
+                .add_modifier(Modifier::BOLD)
+        };
+        spans.push(Span::styled(label, style));
+        cursor = cursor.saturating_add(seg.width);
+    }
+    if cursor < total_width {
+        spans.push(Span::raw(" ".repeat((total_width - cursor) as usize)));
+    }
+    Line::from(spans)
+}
+
+fn card_timeline_line<'a>(
+    card: &Card,
+    iter_field_id: &str,
+    all_iterations: &[IterationOption],
+    segments: &'a [TimelineSegment],
+    total_width: u16,
+) -> Line<'a> {
+    let iteration_id = card.custom_fields.iter().find_map(|fv| match fv {
+        CustomFieldValue::Iteration {
+            field_id,
+            iteration_id,
+            ..
+        } if field_id == iter_field_id => Some(iteration_id.clone()),
+        _ => None,
+    });
+
+    let Some(iteration_id) = iteration_id else {
+        return unscheduled_line(total_width);
+    };
+
+    let Some((idx, seg)) = segments
+        .iter()
+        .enumerate()
+        .find(|(_, s)| s.iteration_id == iteration_id)
+    else {
+        // 表示範囲外の iteration。start_date を参照して方向矢印を出す
+        return out_of_range_line(all_iterations, segments, &iteration_id, total_width);
+    };
+
+    let color = palette_color(idx);
+    let bar = build_bar(seg.width as usize);
+
+    let mut spans: Vec<Span<'a>> = Vec::new();
+    if seg.start_col > 0 {
+        spans.push(Span::raw(" ".repeat(seg.start_col as usize)));
+    }
+    spans.push(Span::styled(bar, Style::default().fg(color)));
+    let filled = seg.start_col.saturating_add(seg.width);
+    if filled < total_width {
+        spans.push(Span::raw(" ".repeat((total_width - filled) as usize)));
+    }
+    Line::from(spans)
+}
+
+fn build_bar(width: usize) -> String {
+    match width {
+        0 => String::new(),
+        1 => "█".to_string(),
+        2 => "▐▌".to_string(),
+        n => {
+            let mut s = String::with_capacity(n * 3);
+            s.push('▐');
+            for _ in 0..(n - 2) {
+                s.push('█');
+            }
+            s.push('▌');
+            s
+        }
+    }
+}
+
+fn unscheduled_line<'a>(total_width: u16) -> Line<'a> {
+    let placeholder = "- not scheduled -";
+    let padded = truncate_pad(placeholder, total_width as usize);
+    Line::from(Span::styled(
+        padded,
+        Style::default().fg(theme().text_muted),
+    ))
+}
+
+/// 表示ウィンドウ外の iteration を指す矢印マーカーを描画する。
+/// card の iteration start_date が window の先頭より前なら ◀、末尾より後なら ▶。
+fn out_of_range_line<'a>(
+    all_iterations: &[IterationOption],
+    segments: &'a [TimelineSegment],
+    iteration_id: &str,
+    total_width: u16,
+) -> Line<'a> {
+    let card_date = all_iterations
+        .iter()
+        .find(|it| it.id == iteration_id)
+        .map(|it| it.start_date.as_str())
+        .unwrap_or("");
+    let first_date = segments.first().map(|s| s.start_date.as_str()).unwrap_or("");
+    let direction = if !card_date.is_empty() && card_date < first_date {
+        "◀"
+    } else {
+        "▶"
+    };
+    let padded = truncate_pad(direction, total_width as usize);
+    Line::from(Span::styled(
+        padded,
+        Style::default().fg(theme().text_dim),
+    ))
+}
+
+fn truncate_pad(s: &str, width: usize) -> String {
+    if width == 0 {
+        return String::new();
+    }
+    let mut out = String::with_capacity(width);
+    let mut used = 0;
+    for ch in s.chars() {
+        let cw = UnicodeWidthChar::width(ch).unwrap_or(0);
+        if used + cw > width {
+            break;
+        }
+        out.push(ch);
+        used += cw;
+    }
+    while used < width {
+        out.push(' ');
+        used += 1;
+    }
+    out
+}
+
+fn palette_color(idx: usize) -> ratatui::style::Color {
+    let palette = [
+        theme().blue,
+        theme().green,
+        theme().orange,
+        theme().purple,
+        theme().pink,
+    ];
+    palette[idx % palette.len()]
+}

--- a/src/ui/statusline.rs
+++ b/src/ui/statusline.rs
@@ -64,6 +64,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
     let layout_label = match app.state.current_layout {
         LayoutMode::Board => "Board",
         LayoutMode::Table => "Table",
+        LayoutMode::Roadmap => "Roadmap",
     };
     spans.push(Span::styled(
         format!("[{layout_label}]"),
@@ -158,6 +159,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
         let mode = match app.state.current_layout {
             LayoutMode::Board => KeymapMode::Board,
             LayoutMode::Table => KeymapMode::Table,
+            LayoutMode::Roadmap => KeymapMode::Roadmap,
         };
         let hints: Vec<String> = [
             (Action::OpenDetail, "detail"),


### PR DESCRIPTION
resolve #28 

## Summary

- `LayoutMode::Roadmap` を追加し、`t` キーで Board → Table → Roadmap → Board を cycle (Iteration field が無い project では Roadmap は skip)
- 横軸は Iteration field の start_date + duration で bar 描画、縦軸は現在の Grouping を流用。未割当カードは `- not scheduled -`
- Pure な時間軸計算 (`src/model/roadmap.rs`) を chrono なしで実装 (Hinnant アルゴリズム)。今日を含む ±2 iteration のウィンドウを duration 比で配分

## Scope

### 対応済み

- Iteration field の可視化 (bar + 今日を含む iteration のハイライト)
- per-view TOML 設定 `layout = "roadmap"`
- ヘルプ / ステータスラインの Roadmap 対応

### スコープ外 (別 issue)

- #47 h/l で Iteration を前後移動
- #48 Date field の start/target 描画
- #49 ズーム切替 + 横スクロール
- #50 `is:scheduled` フィルタ DSL
- #51 マウスドラッグ編集

## Test plan

- [x] \`cargo test\` — 331 passed (Roadmap pure 関数 10 件 + 3-way cycle / Roadmap ナビゲーション テスト追加)
- [x] \`cargo clippy -- -D warnings\` — クリーン
- [x] \`cargo build --release\` — OK
- [ ] 実プロジェクトでの動作確認 (Iteration field 付き / 無し両方)
- [ ] TOML \`layout = "roadmap"\` 指定時の起動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)