### PR TITLE
Add CLI subcommands for coding agent integration

### DIFF
--- a/assets/skills.md
+++ b/assets/skills.md
@@ -1,0 +1,157 @@
+---
+name: gh-board
+description: Manage GitHub Projects V2 kanban boards from the CLI. List projects, view boards, create/move/archive cards, manage comments and fields. All commands output JSON.
+---
+
+# gh-board CLI Skills
+
+gh-board provides CLI subcommands for programmatic access to GitHub Projects V2. All commands output JSON to stdout.
+
+## Authentication
+
+Uses `gh auth token` for authentication. Ensure you're logged in:
+```
+gh auth login
+gh auth refresh -s project
+```
+
+## Commands
+
+### Project
+
+```bash
+# List projects for current user
+gh board project list
+
+# List projects for an org or user
+gh board project list --owner <LOGIN>
+
+# View project details
+gh board project view <NUMBER> [--owner <LOGIN>]
+```
+
+### Board
+
+```bash
+# Get full board as JSON (columns, cards, fields)
+gh board board view <NUMBER> [--owner <LOGIN>] [--group-by <FIELD_NAME>]
+
+# List archived cards
+gh board board archived <NUMBER> [--owner <LOGIN>]
+```
+
+### Card
+
+```bash
+# Create a draft issue on the project
+gh board card create <NUMBER> --title <TITLE> [--body <BODY>] [--owner <LOGIN>] [--status <STATUS_NAME>]
+
+# Create a real issue and add it to the project
+gh board card create-issue <NUMBER> --repo <OWNER/REPO> --title <TITLE> [--body <BODY>] [--owner <LOGIN>] [--status <STATUS_NAME>]
+
+# Get card details (Issue only, by content node ID)
+gh board card get <CONTENT_ID>
+
+# Edit a card (update title/body)
+gh board card edit <CONTENT_ID> --type <draft|issue|pr> --title <TITLE> [--body <BODY>]
+
+# Move a card (update a field value)
+gh board card move <PROJECT_ID> <ITEM_ID> --field-id <FIELD_ID> --value <VALUE> [--value-type <single_select|iteration|text|number|date>]
+
+# Archive / unarchive a card
+gh board card archive <PROJECT_ID> <ITEM_ID>
+gh board card unarchive <PROJECT_ID> <ITEM_ID>
+```
+
+### Comment
+
+```bash
+# List comments on an issue/PR
+gh board comment list <CONTENT_ID>
+
+# Add a comment
+gh board comment add <CONTENT_ID> --body <BODY>
+
+# Update a comment
+gh board comment update <COMMENT_ID> --body <BODY>
+```
+
+### Field
+
+```bash
+# List field definitions (SingleSelect options, Iteration, Text, Number, Date)
+gh board field list <NUMBER> [--owner <LOGIN>]
+```
+
+### Label
+
+```bash
+# List labels for a repository
+gh board label list --repo <OWNER/REPO>
+```
+
+### Assignee
+
+```bash
+# List assignable users for a repository
+gh board assignee list --repo <OWNER/REPO>
+```
+
+### Skill
+
+```bash
+# Output this document
+gh board skill
+```
+
+## Common Workflows
+
+### 1. View a project board
+
+```bash
+# Find the project number
+gh board project list --owner myorg
+
+# Get the board
+gh board board view 5 --owner myorg
+```
+
+### 2. Create an issue and set status
+
+```bash
+# Create a draft issue with initial status
+gh board card create 5 --owner myorg --title "Fix login bug" --body "Details..." --status "In Progress"
+
+# Or create a real issue in a repo
+gh board card create-issue 5 --owner myorg --repo myorg/myrepo --title "Fix login bug" --status "Todo"
+```
+
+### 3. Move a card to a different status
+
+```bash
+# First, get field definitions to find field_id and option_id
+gh board field list 5 --owner myorg
+
+# Then move the card (use the option_id from field list)
+gh board card move <PROJECT_ID> <ITEM_ID> --field-id <FIELD_ID> --value <OPTION_ID>
+```
+
+### 4. Add a comment to an issue
+
+```bash
+# Get the board to find content_id
+gh board board view 5 --owner myorg
+
+# Add a comment using the content_id from a card
+gh board comment add <CONTENT_ID> --body "This is my comment"
+```
+
+## Node IDs
+
+Many commands use GitHub GraphQL node IDs. These are opaque strings like `PVT_kwHOAB...`. You can obtain them from the JSON output of other commands:
+
+- `project_id`: from `gh board project view` → `.id`
+- `item_id`: from `gh board board view` → `.columns[].cards[].item_id`
+- `content_id`: from `gh board board view` → `.columns[].cards[].content_id`
+- `field_id`: from `gh board field list` → `[].id` (for SingleSelect) or nested `.id`
+- `option_id`: from `gh board field list` → SingleSelect's `.options[].id`

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,524 @@
+use anyhow::{bail, Context};
+use clap::Subcommand;
+
+use crate::command::CustomFieldValueInput;
+use crate::github::client::GitHubClient;
+use crate::model::project::ProjectSummary;
+
+#[derive(Subcommand)]
+pub enum CliCommand {
+    /// List and view projects
+    Project {
+        #[command(subcommand)]
+        action: ProjectAction,
+    },
+    /// View board data
+    Board {
+        #[command(subcommand)]
+        action: BoardAction,
+    },
+    /// Manage cards on a project board
+    Card {
+        #[command(subcommand)]
+        action: CardAction,
+    },
+    /// Manage comments on issues/PRs
+    Comment {
+        #[command(subcommand)]
+        action: CommentAction,
+    },
+    /// List field definitions for a project
+    Field {
+        #[command(subcommand)]
+        action: FieldAction,
+    },
+    /// List labels for a repository
+    Label {
+        #[command(subcommand)]
+        action: LabelAction,
+    },
+    /// List assignable users for a repository
+    Assignee {
+        #[command(subcommand)]
+        action: AssigneeAction,
+    },
+    /// Output skills.md describing available CLI commands
+    Skill,
+}
+
+#[derive(Subcommand)]
+pub enum ProjectAction {
+    /// List projects
+    List {
+        /// Login of the owner (org or user). Omit for current user.
+        #[arg(long)]
+        owner: Option<String>,
+    },
+    /// View project details
+    View {
+        /// Project number
+        number: i32,
+        /// Login of the owner
+        #[arg(long)]
+        owner: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum BoardAction {
+    /// Get board as JSON
+    View {
+        /// Project number
+        number: i32,
+        /// Login of the owner
+        #[arg(long)]
+        owner: Option<String>,
+        /// Field name to group by (e.g. "Status", "Sprint")
+        #[arg(long)]
+        group_by: Option<String>,
+    },
+    /// List archived cards
+    Archived {
+        /// Project number
+        number: i32,
+        /// Login of the owner
+        #[arg(long)]
+        owner: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum CardAction {
+    /// Create a draft issue on the project
+    Create {
+        /// Project number
+        number: i32,
+        /// Card title
+        #[arg(long)]
+        title: String,
+        /// Card body
+        #[arg(long, default_value = "")]
+        body: String,
+        /// Login of the owner
+        #[arg(long)]
+        owner: Option<String>,
+        /// Initial status name (must match a SingleSelect option)
+        #[arg(long)]
+        status: Option<String>,
+    },
+    /// Create a real issue and add it to the project
+    CreateIssue {
+        /// Project number
+        number: i32,
+        /// Repository in OWNER/REPO format
+        #[arg(long)]
+        repo: String,
+        /// Issue title
+        #[arg(long)]
+        title: String,
+        /// Issue body
+        #[arg(long, default_value = "")]
+        body: String,
+        /// Login of the owner
+        #[arg(long)]
+        owner: Option<String>,
+        /// Initial status name (must match a SingleSelect option)
+        #[arg(long)]
+        status: Option<String>,
+    },
+    /// Archive a card
+    Archive {
+        /// Project node ID
+        project_id: String,
+        /// Item node ID
+        item_id: String,
+    },
+    /// Unarchive a card
+    Unarchive {
+        /// Project node ID
+        project_id: String,
+        /// Item node ID
+        item_id: String,
+    },
+    /// Move a card (update a field value)
+    Move {
+        /// Project node ID
+        project_id: String,
+        /// Item node ID
+        item_id: String,
+        /// Field node ID
+        #[arg(long)]
+        field_id: String,
+        /// Value to set
+        #[arg(long)]
+        value: String,
+        /// Value type: single_select, iteration, text, number, date
+        #[arg(long, default_value = "single_select")]
+        value_type: String,
+    },
+    /// Edit a card (update title/body)
+    Edit {
+        /// Content node ID (Issue/PR/DraftIssue ID)
+        content_id: String,
+        /// Card type: draft, issue, pr
+        #[arg(long, name = "type")]
+        card_type: String,
+        /// New title
+        #[arg(long)]
+        title: String,
+        /// New body
+        #[arg(long, default_value = "")]
+        body: String,
+    },
+    /// Get card details (Issue only)
+    Get {
+        /// Content node ID
+        content_id: String,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum CommentAction {
+    /// List comments on an issue/PR
+    List {
+        /// Content node ID (Issue or PR)
+        content_id: String,
+    },
+    /// Add a comment
+    Add {
+        /// Content node ID (Issue or PR)
+        content_id: String,
+        /// Comment body
+        #[arg(long)]
+        body: String,
+    },
+    /// Update a comment
+    Update {
+        /// Comment node ID
+        comment_id: String,
+        /// New comment body
+        #[arg(long)]
+        body: String,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum FieldAction {
+    /// List field definitions for a project
+    List {
+        /// Project number
+        number: i32,
+        /// Login of the owner
+        #[arg(long)]
+        owner: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum LabelAction {
+    /// List labels for a repository
+    List {
+        /// Repository in OWNER/REPO format
+        #[arg(long)]
+        repo: String,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum AssigneeAction {
+    /// List assignable users for a repository
+    List {
+        /// Repository in OWNER/REPO format
+        #[arg(long)]
+        repo: String,
+    },
+}
+
+pub async fn run(cmd: CliCommand, github: GitHubClient) -> anyhow::Result<()> {
+    match cmd {
+        CliCommand::Project { action } => run_project(action, &github).await,
+        CliCommand::Board { action } => run_board(action, &github).await,
+        CliCommand::Card { action } => run_card(action, &github).await,
+        CliCommand::Comment { action } => run_comment(action, &github).await,
+        CliCommand::Field { action } => run_field(action, &github).await,
+        CliCommand::Label { action } => run_label(action, &github).await,
+        CliCommand::Assignee { action } => run_assignee(action, &github).await,
+        CliCommand::Skill => {
+            print!("{}", include_str!("../assets/skills.md"));
+            Ok(())
+        }
+    }
+}
+
+async fn resolve_project(
+    github: &GitHubClient,
+    number: i32,
+    owner: Option<&str>,
+) -> anyhow::Result<ProjectSummary> {
+    if let Some(owner) = owner {
+        github.get_owner_project_by_number(owner, number).await
+    } else {
+        github.get_viewer_project_by_number(number).await
+    }
+}
+
+fn parse_repo(repo: &str) -> anyhow::Result<(&str, &str)> {
+    let parts: Vec<&str> = repo.splitn(2, '/').collect();
+    if parts.len() != 2 {
+        bail!("Repository must be in OWNER/REPO format, got: {repo}");
+    }
+    Ok((parts[0], parts[1]))
+}
+
+fn print_json<T: serde::Serialize>(value: &T) -> anyhow::Result<()> {
+    println!(
+        "{}",
+        serde_json::to_string_pretty(value).context("Failed to serialize JSON")?
+    );
+    Ok(())
+}
+
+async fn run_project(action: ProjectAction, github: &GitHubClient) -> anyhow::Result<()> {
+    match action {
+        ProjectAction::List { owner } => {
+            let projects = if let Some(owner) = owner {
+                github.list_owner_projects(&owner).await?
+            } else {
+                github.list_viewer_projects().await?
+            };
+            print_json(&projects)
+        }
+        ProjectAction::View { number, owner } => {
+            let project = resolve_project(github, number, owner.as_deref()).await?;
+            print_json(&project)
+        }
+    }
+}
+
+async fn run_board(action: BoardAction, github: &GitHubClient) -> anyhow::Result<()> {
+    match action {
+        BoardAction::View {
+            number,
+            owner,
+            group_by,
+        } => {
+            let project = resolve_project(github, number, owner.as_deref()).await?;
+            let board = github
+                .get_board(&project.id, &[], group_by.as_deref())
+                .await?;
+            print_json(&board)
+        }
+        BoardAction::Archived { number, owner } => {
+            let project = resolve_project(github, number, owner.as_deref()).await?;
+            let cards = github.get_archived_items(&project.id).await?;
+            print_json(&cards)
+        }
+    }
+}
+
+async fn run_card(action: CardAction, github: &GitHubClient) -> anyhow::Result<()> {
+    match action {
+        CardAction::Create {
+            number,
+            title,
+            body,
+            owner,
+            status,
+        } => {
+            let project = resolve_project(github, number, owner.as_deref()).await?;
+            let item_id = github.create_draft_issue(&project.id, &title, &body).await?;
+            if let Some(status_name) = status {
+                set_initial_status(github, &project.id, &item_id, &status_name).await?;
+            }
+            print_json(&serde_json::json!({ "item_id": item_id }))
+        }
+        CardAction::CreateIssue {
+            number,
+            repo,
+            title,
+            body,
+            owner,
+            status,
+        } => {
+            let project = resolve_project(github, number, owner.as_deref()).await?;
+            let board = github.get_board(&project.id, &[], None).await?;
+            let (repo_owner, repo_name) = parse_repo(&repo)?;
+            let repository = board
+                .repositories
+                .iter()
+                .find(|r| r.name_with_owner == repo)
+                .with_context(|| {
+                    format!(
+                        "Repository '{repo}' not linked to this project. Available: {}",
+                        board
+                            .repositories
+                            .iter()
+                            .map(|r| r.name_with_owner.as_str())
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    )
+                })?;
+            let _ = (repo_owner, repo_name); // used for validation above
+            let issue_id = github.create_issue(&repository.id, &title, &body).await?;
+            let item_id = github.add_project_item(&project.id, &issue_id).await?;
+            if let Some(status_name) = status {
+                set_initial_status(github, &project.id, &item_id, &status_name).await?;
+            }
+            print_json(&serde_json::json!({
+                "item_id": item_id,
+                "issue_id": issue_id,
+            }))
+        }
+        CardAction::Archive {
+            project_id,
+            item_id,
+        } => {
+            github.archive_card(&project_id, &item_id).await?;
+            print_json(&serde_json::json!({ "ok": true }))
+        }
+        CardAction::Unarchive {
+            project_id,
+            item_id,
+        } => {
+            github.unarchive_card(&project_id, &item_id).await?;
+            print_json(&serde_json::json!({ "ok": true }))
+        }
+        CardAction::Move {
+            project_id,
+            item_id,
+            field_id,
+            value,
+            value_type,
+        } => {
+            let input = parse_field_value(&value_type, &value)?;
+            github
+                .update_custom_field(&project_id, &item_id, &field_id, &input)
+                .await?;
+            print_json(&serde_json::json!({ "ok": true }))
+        }
+        CardAction::Edit {
+            content_id,
+            card_type,
+            title,
+            body,
+        } => {
+            match card_type.as_str() {
+                "draft" => github.update_draft_issue(&content_id, &title, &body).await?,
+                "issue" => github.update_issue(&content_id, &title, &body).await?,
+                "pr" => github.update_pull_request(&content_id, &title, &body).await?,
+                other => bail!("Unknown card type: '{other}'. Use: draft, issue, pr"),
+            }
+            print_json(&serde_json::json!({ "ok": true }))
+        }
+        CardAction::Get { content_id } => {
+            let card = github.fetch_issue_as_card(&content_id).await?;
+            print_json(&card)
+        }
+    }
+}
+
+async fn run_comment(action: CommentAction, github: &GitHubClient) -> anyhow::Result<()> {
+    match action {
+        CommentAction::List { content_id } => {
+            let comments = github.fetch_all_comments(&content_id).await?;
+            print_json(&comments)
+        }
+        CommentAction::Add { content_id, body } => {
+            let comment = github.add_comment(&content_id, &body).await?;
+            print_json(&comment)
+        }
+        CommentAction::Update { comment_id, body } => {
+            let comment = github.update_comment(&comment_id, &body).await?;
+            print_json(&comment)
+        }
+    }
+}
+
+async fn run_field(action: FieldAction, github: &GitHubClient) -> anyhow::Result<()> {
+    match action {
+        FieldAction::List { number, owner } => {
+            let project = resolve_project(github, number, owner.as_deref()).await?;
+            let board = github.get_board(&project.id, &[], None).await?;
+            print_json(&board.field_definitions)
+        }
+    }
+}
+
+async fn run_label(action: LabelAction, github: &GitHubClient) -> anyhow::Result<()> {
+    match action {
+        LabelAction::List { repo } => {
+            let (owner, name) = parse_repo(&repo)?;
+            let labels = github.get_repo_labels(owner, name).await?;
+            print_json(&labels)
+        }
+    }
+}
+
+async fn run_assignee(action: AssigneeAction, github: &GitHubClient) -> anyhow::Result<()> {
+    match action {
+        AssigneeAction::List { repo } => {
+            let (owner, name) = parse_repo(&repo)?;
+            let users = github.get_assignable_users(owner, name).await?;
+            let users: Vec<_> = users
+                .into_iter()
+                .map(|(id, login)| serde_json::json!({ "id": id, "login": login }))
+                .collect();
+            print_json(&users)
+        }
+    }
+}
+
+fn parse_field_value(value_type: &str, value: &str) -> anyhow::Result<CustomFieldValueInput> {
+    match value_type {
+        "single_select" => Ok(CustomFieldValueInput::SingleSelect {
+            option_id: value.to_string(),
+        }),
+        "iteration" => Ok(CustomFieldValueInput::Iteration {
+            iteration_id: value.to_string(),
+        }),
+        "text" => Ok(CustomFieldValueInput::Text {
+            text: value.to_string(),
+        }),
+        "number" => {
+            let n: f64 = value
+                .parse()
+                .with_context(|| format!("Invalid number: {value}"))?;
+            Ok(CustomFieldValueInput::Number { number: n })
+        }
+        "date" => Ok(CustomFieldValueInput::Date {
+            date: value.to_string(),
+        }),
+        other => bail!("Unknown value type: '{other}'. Use: single_select, iteration, text, number, date"),
+    }
+}
+
+/// Resolve a status name to a field value and set it on the item.
+async fn set_initial_status(
+    github: &GitHubClient,
+    project_id: &str,
+    item_id: &str,
+    status_name: &str,
+) -> anyhow::Result<()> {
+    let board = github.get_board(project_id, &[], None).await?;
+    for def in &board.field_definitions {
+        if let crate::model::project::FieldDefinition::SingleSelect { id, name, options } = def
+            && name == "Status"
+        {
+            if let Some(opt) = options.iter().find(|o| o.name == status_name) {
+                let input = CustomFieldValueInput::SingleSelect {
+                    option_id: opt.id.clone(),
+                };
+                github
+                    .update_custom_field(project_id, item_id, id, &input)
+                    .await?;
+                return Ok(());
+            }
+            let available: Vec<_> = options.iter().map(|o| o.name.as_str()).collect();
+            bail!(
+                "Status '{status_name}' not found. Available: {}",
+                available.join(", ")
+            );
+        }
+    }
+    bail!("No Status field found on this project");
+}

--- a/src/command.rs
+++ b/src/command.rs
@@ -124,7 +124,8 @@ pub enum Command {
     Batch(Vec<Command>),
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum CustomFieldValueInput {
     SingleSelect { option_id: String },
     Iteration { iteration_id: String },

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod action;
 mod app;
 mod app_state;
+mod cli;
 mod command;
 mod config;
 mod event;
@@ -32,6 +33,9 @@ use model::state::{LoadingState, ViewMode};
 #[derive(Parser)]
 #[command(name = "gh-board", about = "View GitHub Projects V2 as a kanban board")]
 struct Cli {
+    #[command(subcommand)]
+    command: Option<cli::CliCommand>,
+
     /// Project number to open directly
     number: Option<i32>,
 
@@ -42,6 +46,20 @@ struct Cli {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    // CLI subcommand mode: no TUI initialization
+    if let Some(cmd) = cli.command {
+        let github = GitHubClient::new().await?;
+        if let Err(e) = cli::run(cmd, github).await {
+            let msg = serde_json::json!({ "error": format!("{e:#}") });
+            eprintln!("{}", serde_json::to_string_pretty(&msg).unwrap_or_default());
+            std::process::exit(1);
+        }
+        return Ok(());
+    }
+
+    // TUI mode
     let cfg = config::load_config().unwrap_or_else(|e| {
         eprintln!("Warning: failed to load config: {e}");
         config::Config::default()
@@ -53,7 +71,6 @@ async fn main() -> Result<()> {
     let default_theme = config::ThemeConfig::default();
     ui::theme::init_theme(theme_cfg.as_ref().unwrap_or(&default_theme));
 
-    let cli = Cli::parse();
     let github = GitHubClient::new().await?;
 
     let mut terminal = ratatui::init();

--- a/src/model/project.rs
+++ b/src/model/project.rs
@@ -1,4 +1,4 @@
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct ProjectSummary {
     pub id: String,
     pub title: String,
@@ -6,7 +6,7 @@ pub struct ProjectSummary {
     pub description: Option<String>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct Board {
     pub project_title: String,
     pub grouping: Grouping,
@@ -17,7 +17,8 @@ pub struct Board {
 
 /// カンバンをグルーピングする軸 (SingleSelect or Iteration)。
 /// grouping が未決定のプロジェクト (groupable field がない) では None と同等の扱いで空 columns を返す。
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum Grouping {
     SingleSelect { field_id: String, field_name: String },
     Iteration { field_id: String, field_name: String },
@@ -63,7 +64,7 @@ impl Board {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct Column {
     pub option_id: String,
     pub name: String,
@@ -71,7 +72,8 @@ pub struct Column {
     pub cards: Vec<Card>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum ColumnColor {
     Blue,
     Gray,
@@ -83,7 +85,7 @@ pub enum ColumnColor {
     Yellow,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct Card {
     pub item_id: String,
     pub content_id: Option<String>,
@@ -106,7 +108,7 @@ pub struct Card {
     pub sub_issues: Vec<SubIssueRef>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize)]
 pub struct ParentIssueRef {
     pub id: String,
     pub number: i32,
@@ -114,7 +116,7 @@ pub struct ParentIssueRef {
     pub url: Option<String>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize)]
 pub struct SubIssueRef {
     pub id: String,
     pub number: i32,
@@ -123,13 +125,13 @@ pub struct SubIssueRef {
     pub url: Option<String>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize)]
 pub struct SubIssuesSummary {
     pub completed: i32,
     pub total: i32,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize)]
 pub struct LinkedPr {
     pub number: i32,
     pub title: String,
@@ -137,14 +139,15 @@ pub struct LinkedPr {
     pub state: PrState,
 }
 
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, serde::Serialize)]
 pub struct PrStatus {
     pub ci: Option<CiStatus>,
     pub review_decision: Option<ReviewDecision>,
     pub review_requests: Vec<String>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum CiStatus {
     Success,
     Failure,
@@ -153,14 +156,16 @@ pub enum CiStatus {
     Expected,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum ReviewDecision {
     Approved,
     ChangesRequested,
     ReviewRequired,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum FieldDefinition {
     SingleSelect {
         id: String,
@@ -208,14 +213,14 @@ impl FieldDefinition {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize)]
 pub struct SingleSelectOption {
     pub id: String,
     pub name: String,
     pub color: Option<ColumnColor>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize)]
 pub struct IterationOption {
     pub id: String,
     pub title: String,
@@ -224,7 +229,8 @@ pub struct IterationOption {
     pub completed: bool,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum CustomFieldValue {
     SingleSelect {
         field_id: String,
@@ -263,7 +269,7 @@ impl CustomFieldValue {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct Comment {
     pub id: String,
     pub author: String,
@@ -272,7 +278,8 @@ pub struct Comment {
     pub reactions: Vec<ReactionSummary>,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum ReactionContent {
     ThumbsUp,
     ThumbsDown,
@@ -312,7 +319,7 @@ impl ReactionContent {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize)]
 pub struct ReactionSummary {
     pub content: ReactionContent,
     pub count: usize,
@@ -349,34 +356,37 @@ pub fn apply_reaction_toggle(
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum CardType {
     Issue { state: IssueState },
     PullRequest { state: PrState },
     DraftIssue,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum IssueState {
     Open,
     Closed,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum PrState {
     Open,
     Closed,
     Merged,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct Label {
     pub id: String,
     pub name: String,
     pub color: String,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct Repository {
     pub id: String,
     pub name_with_owner: String,


### PR DESCRIPTION
## Summary

- Coding Agent (Claude Code, Codex 等) が gh-board を CLI 経由で操作できるよう、JSON 出力のサブコマンドを追加
- `project`, `board`, `card`, `comment`, `field`, `label`, `assignee` の各リソースに対する CRUD 操作を提供
- `gh board skill` で Agent Skills 標準 (YAML frontmatter 付き) のコマンドドキュメントを出力

### 追加されたサブコマンド

| コマンド | 説明 |
|---------|------|
| `project list/view` | プロジェクト一覧・詳細 |
| `board view/archived` | ボード取得・アーカイブ一覧 |
| `card create/create-issue/get/edit/move/archive/unarchive` | カード CRUD |
| `comment list/add/update` | コメント操作 |
| `field list` | フィールド定義一覧 |
| `label list` | ラベル一覧 |
| `assignee list` | アサイン可能ユーザー一覧 |
| `skill` | Agent Skills 標準の SKILL.md を出力 |

Closes #46

## Test plan

- [x] `cargo build` — コンパイル通過
- [x] `cargo test` — 全 331 テスト通過
- [x] `cargo clippy -- -D warnings` — 警告なし
- [x] `cargo run -- skill` — frontmatter 付き skills.md 出力
- [x] `cargo run -- project list` — JSON でプロジェクト一覧
- [x] `cargo run -- board view 1` — JSON でボード取得
- [x] `cargo run` (引数なし) — 従来の TUI モードが起動
- [x] `cargo run -- --help` — サブコマンド一覧表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)