### PR TITLE
Add `item list` CLI subcommand with custom field values

### DIFF
--- a/assets/skills.md
+++ b/assets/skills.md
@@ -40,6 +40,15 @@ gh board board view <NUMBER> [--owner <LOGIN>] [--group-by <FIELD_NAME>]
 gh board board archived <NUMBER> [--owner <LOGIN>]
 ```
 
+### Item
+
+```bash
+# List all items in a project (flat list with custom field values)
+gh board item list <NUMBER> [--owner <LOGIN>]
+```
+
+Each item includes `custom_fields` containing all project field values (Priority, Sprint, etc.).
+
 ### Card
 
 ```bash
@@ -151,7 +160,7 @@ gh board comment add <CONTENT_ID> --body "This is my comment"
 Many commands use GitHub GraphQL node IDs. These are opaque strings like `PVT_kwHOAB...`. You can obtain them from the JSON output of other commands:
 
 - `project_id`: from `gh board project view` → `.id`
-- `item_id`: from `gh board board view` → `.columns[].cards[].item_id`
+- `item_id`: from `gh board board view` → `.columns[].cards[].item_id` or `gh board item list` → `[].item_id`
 - `content_id`: from `gh board board view` → `.columns[].cards[].content_id`
 - `field_id`: from `gh board field list` → `[].id` (for SingleSelect) or nested `.id`
 - `option_id`: from `gh board field list` → SingleSelect's `.options[].id`

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -1251,7 +1251,7 @@ impl AppState {
             let target_key = board.columns[target_column].option_id.clone();
             card.custom_fields.retain(|fv| fv.field_id() != field_id);
             match &board.grouping {
-                crate::model::project::Grouping::SingleSelect { .. } => {
+                crate::model::project::Grouping::SingleSelect { field_name: gfn, .. } => {
                     let (name, color) = board
                         .field_definitions
                         .iter()
@@ -1269,12 +1269,13 @@ impl AppState {
                         .unwrap_or_default();
                     card.custom_fields.push(CustomFieldValue::SingleSelect {
                         field_id: field_id.clone(),
+                        field_name: gfn.clone(),
                         option_id: target_key.clone(),
                         name,
                         color,
                     });
                 }
-                crate::model::project::Grouping::Iteration { .. } => {
+                crate::model::project::Grouping::Iteration { field_name: gfn, .. } => {
                     let title = board
                         .field_definitions
                         .iter()
@@ -1292,6 +1293,7 @@ impl AppState {
                         .unwrap_or_default();
                     card.custom_fields.push(CustomFieldValue::Iteration {
                         field_id: field_id.clone(),
+                        field_name: gfn.clone(),
                         iteration_id: target_key.clone(),
                         title,
                     });
@@ -2174,7 +2176,7 @@ impl AppState {
             {
                 card.custom_fields.retain(|fv| fv.field_id() != field_id);
                 match &board.grouping {
-                    crate::model::project::Grouping::SingleSelect { .. } => {
+                    crate::model::project::Grouping::SingleSelect { field_name: gfn, .. } => {
                         let (name, color) = board
                             .field_definitions
                             .iter()
@@ -2192,12 +2194,13 @@ impl AppState {
                             .unwrap_or_default();
                         card.custom_fields.push(CustomFieldValue::SingleSelect {
                             field_id: field_id.clone(),
+                            field_name: gfn.clone(),
                             option_id: target_key.clone(),
                             name,
                             color,
                         });
                     }
-                    crate::model::project::Grouping::Iteration { .. } => {
+                    crate::model::project::Grouping::Iteration { field_name: gfn, .. } => {
                         let title = board
                             .field_definitions
                             .iter()
@@ -2215,6 +2218,7 @@ impl AppState {
                             .unwrap_or_default();
                         card.custom_fields.push(CustomFieldValue::Iteration {
                             field_id: field_id.clone(),
+                            field_name: gfn.clone(),
                             iteration_id: target_key.clone(),
                             title,
                         });
@@ -3747,6 +3751,7 @@ impl AppState {
         {
             Some(SidebarEditMode::CustomFieldSingleSelect {
                 field_id,
+                field_name,
                 options,
                 cursor,
                 ..
@@ -3766,6 +3771,7 @@ impl AppState {
                     let opt = &options[cursor];
                     let new_val = CustomFieldValue::SingleSelect {
                         field_id: field_id.clone(),
+                        field_name: field_name.clone(),
                         option_id: opt.id.clone(),
                         name: opt.name.clone(),
                         color: opt.color.clone(),
@@ -3786,6 +3792,7 @@ impl AppState {
             }
             Some(SidebarEditMode::CustomFieldIteration {
                 field_id,
+                field_name,
                 iterations,
                 cursor,
                 ..
@@ -3804,6 +3811,7 @@ impl AppState {
                     let it = &iterations[cursor];
                     let new_val = CustomFieldValue::Iteration {
                         field_id: field_id.clone(),
+                        field_name: field_name.clone(),
                         iteration_id: it.id.clone(),
                         title: it.title.clone(),
                     };
@@ -3933,7 +3941,7 @@ impl AppState {
         let edit = self.sidebar_edit.take();
         match edit {
             Some(SidebarEditMode::CustomFieldText {
-                field_id, input, ..
+                field_id, field_name, input, ..
             }) => {
                 if input.is_empty() {
                     self.apply_custom_field_optimistic(&field_id, None);
@@ -3945,6 +3953,7 @@ impl AppState {
                 } else {
                     let new_val = CustomFieldValue::Text {
                         field_id: field_id.clone(),
+                        field_name: field_name.clone(),
                         text: input.clone(),
                     };
                     self.apply_custom_field_optimistic(&field_id, Some(new_val));
@@ -3974,6 +3983,7 @@ impl AppState {
                     Ok(n) if n.is_finite() => {
                         let new_val = CustomFieldValue::Number {
                             field_id: field_id.clone(),
+                            field_name: field_name.clone(),
                             number: n,
                         };
                         self.apply_custom_field_optimistic(&field_id, Some(new_val));
@@ -4013,6 +4023,7 @@ impl AppState {
                 if is_valid_iso_date(&input) {
                     let new_val = CustomFieldValue::Date {
                         field_id: field_id.clone(),
+                        field_name: field_name.clone(),
                         date: input.clone(),
                     };
                     self.apply_custom_field_optimistic(&field_id, Some(new_val));
@@ -8431,6 +8442,7 @@ mod tests {
             "Card A",
             vec![CustomFieldValue::SingleSelect {
                 field_id: "fld_priority".into(),
+                field_name: "Priority".into(),
                 option_id: "opt_p1".into(),
                 name: "P1".into(),
                 color: Some(ColumnColor::Orange),
@@ -8500,6 +8512,7 @@ mod tests {
             "Card A",
             vec![CustomFieldValue::SingleSelect {
                 field_id: "fld_priority".into(),
+                field_name: "Priority".into(),
                 option_id: "opt_p1".into(),
                 name: "P1".into(),
                 color: Some(ColumnColor::Orange),
@@ -8734,6 +8747,7 @@ mod tests {
                         "A",
                         vec![CustomFieldValue::SingleSelect {
                             field_id: "field_priority".into(),
+                            field_name: "Priority".into(),
                             option_id: "opt_p1".into(),
                             name: "P1".into(),
                             color: None,
@@ -8744,6 +8758,7 @@ mod tests {
                         "B",
                         vec![CustomFieldValue::Iteration {
                             field_id: "field_sprint".into(),
+                            field_name: "Sprint".into(),
                             iteration_id: "it_1".into(),
                             title: "Sprint 1".into(),
                         }],
@@ -9026,6 +9041,7 @@ mod tests {
             .custom_fields
             .push(CustomFieldValue::SingleSelect {
                 field_id: "field_status".into(),
+                field_name: "Status".into(),
                 option_id: "opt_todo".into(),
                 name: "Todo".into(),
                 color: None,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -42,6 +42,11 @@ pub enum CliCommand {
         #[command(subcommand)]
         action: AssigneeAction,
     },
+    /// List project items
+    Item {
+        #[command(subcommand)]
+        action: ItemAction,
+    },
     /// Output skills.md describing available CLI commands
     Skill,
 }
@@ -234,6 +239,18 @@ pub enum AssigneeAction {
     },
 }
 
+#[derive(Subcommand)]
+pub enum ItemAction {
+    /// List all items in a project (flat list with custom fields)
+    List {
+        /// Project number
+        number: i32,
+        /// Login of the owner
+        #[arg(long)]
+        owner: Option<String>,
+    },
+}
+
 pub async fn run(cmd: CliCommand, github: GitHubClient) -> anyhow::Result<()> {
     match cmd {
         CliCommand::Project { action } => run_project(action, &github).await,
@@ -243,6 +260,7 @@ pub async fn run(cmd: CliCommand, github: GitHubClient) -> anyhow::Result<()> {
         CliCommand::Field { action } => run_field(action, &github).await,
         CliCommand::Label { action } => run_label(action, &github).await,
         CliCommand::Assignee { action } => run_assignee(action, &github).await,
+        CliCommand::Item { action } => run_item(action, &github).await,
         CliCommand::Skill => {
             print!("{}", include_str!("../assets/skills.md"));
             Ok(())
@@ -464,6 +482,17 @@ async fn run_assignee(action: AssigneeAction, github: &GitHubClient) -> anyhow::
                 .map(|(id, login)| serde_json::json!({ "id": id, "login": login }))
                 .collect();
             print_json(&users)
+        }
+    }
+}
+
+async fn run_item(action: ItemAction, github: &GitHubClient) -> anyhow::Result<()> {
+    match action {
+        ItemAction::List { number, owner } => {
+            let project = resolve_project(github, number, owner.as_deref()).await?;
+            let board = github.get_board(&project.id, &[], None).await?;
+            let cards: Vec<_> = board.columns.into_iter().flat_map(|col| col.cards).collect();
+            print_json(&cards)
         }
     }
 }

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -1173,7 +1173,7 @@ fn build_board(
                         && let Some(option_id) = sv.option_id.clone()
                     {
                         let def = field_definitions.iter().find(|d| d.id() == f.id);
-                        let Some(FieldDefinition::SingleSelect { options, .. }) = def else {
+                        let Some(FieldDefinition::SingleSelect { name: field_name, options, .. }) = def else {
                             continue;
                         };
                         let color = options
@@ -1182,6 +1182,7 @@ fn build_board(
                             .and_then(|o| o.color.clone());
                         card.custom_fields.push(CustomFieldValue::SingleSelect {
                             field_id: f.id.clone(),
+                            field_name: field_name.clone(),
                             option_id,
                             name: sv.name.clone().unwrap_or_default(),
                             color,
@@ -1191,13 +1192,12 @@ fn build_board(
                 FVNode::ProjectV2ItemFieldTextValue(tv) => {
                     use project_board::ProjectBoardNodeOnProjectV2ItemsNodesFieldValuesNodesOnProjectV2ItemFieldTextValueField as TField;
                     if let TField::ProjectV2Field(f) = &tv.field
-                        && matches!(
-                            field_definitions.iter().find(|d| d.id() == f.id),
-                            Some(FieldDefinition::Text { .. })
-                        )
+                        && let Some(FieldDefinition::Text { name: field_name, .. }) =
+                            field_definitions.iter().find(|d| d.id() == f.id)
                     {
                         card.custom_fields.push(CustomFieldValue::Text {
                             field_id: f.id.clone(),
+                            field_name: field_name.clone(),
                             text: tv.text.clone().unwrap_or_default(),
                         });
                     }
@@ -1206,13 +1206,12 @@ fn build_board(
                     use project_board::ProjectBoardNodeOnProjectV2ItemsNodesFieldValuesNodesOnProjectV2ItemFieldNumberValueField as NField;
                     if let NField::ProjectV2Field(f) = &nv.field
                         && let Some(n) = nv.number
-                        && matches!(
-                            field_definitions.iter().find(|d| d.id() == f.id),
-                            Some(FieldDefinition::Number { .. })
-                        )
+                        && let Some(FieldDefinition::Number { name: field_name, .. }) =
+                            field_definitions.iter().find(|d| d.id() == f.id)
                     {
                         card.custom_fields.push(CustomFieldValue::Number {
                             field_id: f.id.clone(),
+                            field_name: field_name.clone(),
                             number: n,
                         });
                     }
@@ -1221,13 +1220,12 @@ fn build_board(
                     use project_board::ProjectBoardNodeOnProjectV2ItemsNodesFieldValuesNodesOnProjectV2ItemFieldDateValueField as DField;
                     if let DField::ProjectV2Field(f) = &dv.field
                         && let Some(d) = dv.date.clone()
-                        && matches!(
-                            field_definitions.iter().find(|d| d.id() == f.id),
-                            Some(FieldDefinition::Date { .. })
-                        )
+                        && let Some(FieldDefinition::Date { name: field_name, .. }) =
+                            field_definitions.iter().find(|d| d.id() == f.id)
                     {
                         card.custom_fields.push(CustomFieldValue::Date {
                             field_id: f.id.clone(),
+                            field_name: field_name.clone(),
                             date: d,
                         });
                     }
@@ -1235,13 +1233,12 @@ fn build_board(
                 FVNode::ProjectV2ItemFieldIterationValue(iv) => {
                     use project_board::ProjectBoardNodeOnProjectV2ItemsNodesFieldValuesNodesOnProjectV2ItemFieldIterationValueField as IField;
                     if let IField::ProjectV2IterationField(f) = &iv.field
-                        && matches!(
-                            field_definitions.iter().find(|d| d.id() == f.id),
-                            Some(FieldDefinition::Iteration { .. })
-                        )
+                        && let Some(FieldDefinition::Iteration { name: field_name, .. }) =
+                            field_definitions.iter().find(|d| d.id() == f.id)
                     {
                         card.custom_fields.push(CustomFieldValue::Iteration {
                             field_id: f.id.clone(),
+                            field_name: field_name.clone(),
                             iteration_id: iv.iteration_id.clone(),
                             title: iv.title.clone(),
                         });

--- a/src/model/project.rs
+++ b/src/model/project.rs
@@ -234,24 +234,29 @@ pub struct IterationOption {
 pub enum CustomFieldValue {
     SingleSelect {
         field_id: String,
+        field_name: String,
         option_id: String,
         name: String,
         color: Option<ColumnColor>,
     },
     Text {
         field_id: String,
+        field_name: String,
         text: String,
     },
     Number {
         field_id: String,
+        field_name: String,
         number: f64,
     },
     Date {
         field_id: String,
+        field_name: String,
         date: String,
     },
     Iteration {
         field_id: String,
+        field_name: String,
         iteration_id: String,
         title: String,
     },


### PR DESCRIPTION
## Summary
- `gh board item list <NUMBER> [--owner <LOGIN>]` サブコマンドを追加
- プロジェクトの全アイテムをカスタムフィールド（Priority, Sprint 等）付きのフラットな JSON 配列として返却
- 既存の `get_board()` を再利用し、カラム構造をフラット化するだけの最小実装

Closes #56

## Test plan
- [x] `cargo build` 成功
- [x] `cargo clippy -- -D warnings` 警告なし
- [x] `cargo test` 全 331 テスト合格
- [ ] `gh board item list <NUMBER> --owner <OWNER>` で JSON 出力にカスタムフィールドが含まれることを確認
- [ ] `gh board item list <NUMBER> --owner <OWNER> | jq '.[0].custom_fields'` でフィールド値を抽出できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)