### PR TITLE
feat: skill 自己更新手順とリリース通知を追加 (closes #62, #64)

### DIFF
--- a/assets/skills.md.tmpl
+++ b/assets/skills.md.tmpl
@@ -1,11 +1,19 @@
 ---
 name: gh-board
 description: Manage GitHub Projects V2 kanban boards from the CLI. List projects, view boards, create/move/archive cards, manage comments and fields. All commands output JSON.
+version: {{VERSION}}
 ---
 
 # gh-board CLI Skills
 
 gh-board provides CLI subcommands for programmatic access to GitHub Projects V2. All commands output JSON to stdout.
+
+## Keeping this file up to date
+
+This file is shipped with the `gh board` binary and regenerated on every release. Before using any command below, compare the `version` in the frontmatter above with the output of `gh board --version`:
+
+- If they match, proceed normally.
+- If they differ, this file is stale. Regenerate it with `gh board skill > <path to this file>` and reload the skill before continuing. Doing this first avoids calling commands or flags that have since been renamed, added, or removed.
 
 ## Authentication
 

--- a/build.rs
+++ b/build.rs
@@ -7,6 +7,9 @@ fn main() {
 
     println!("cargo::rerun-if-changed=schema.graphql");
     println!("cargo::rerun-if-changed=Cargo.toml");
+    println!("cargo::rerun-if-changed=assets/skills.md.tmpl");
+
+    generate_skills_md(&manifest_dir);
 
     if schema_path.exists() {
         return;
@@ -52,4 +55,19 @@ fn main() {
         "Downloaded schema.graphql ({} bytes)",
         output.stdout.len()
     );
+}
+
+fn generate_skills_md(manifest_dir: &str) {
+    let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR not set");
+    let version = std::env::var("CARGO_PKG_VERSION").expect("CARGO_PKG_VERSION not set");
+
+    let tmpl_path = Path::new(manifest_dir).join("assets/skills.md.tmpl");
+    let tmpl = std::fs::read_to_string(&tmpl_path)
+        .unwrap_or_else(|e| panic!("Failed to read {}: {e}", tmpl_path.display()));
+
+    let rendered = tmpl.replace("{{VERSION}}", &version);
+
+    let dest = Path::new(&out_dir).join("skills.md");
+    std::fs::write(&dest, rendered)
+        .unwrap_or_else(|e| panic!("Failed to write {}: {e}", dest.display()));
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -27,6 +27,9 @@ impl App {
         let viewer_login = github.viewer_login().to_string();
         let mut state = AppState::new(owner);
         state.viewer_login = viewer_login;
+
+        spawn_update_check(event_tx.clone());
+
         Self {
             state,
             pending_editor: None,
@@ -532,4 +535,15 @@ impl App {
             }
         }
     }
+}
+
+fn spawn_update_check(tx: mpsc::UnboundedSender<AppEvent>) {
+    tokio::spawn(async move {
+        let Some(latest) = crate::github::update_check::fetch_latest_version().await else {
+            return;
+        };
+        if crate::github::update_check::is_newer(&latest, env!("CARGO_PKG_VERSION")) {
+            let _ = tx.send(AppEvent::UpdateAvailable(latest));
+        }
+    });
 }

--- a/src/app_state/mod.rs
+++ b/src/app_state/mod.rs
@@ -181,6 +181,9 @@ pub struct AppState {
     /// overlay シーン (ReactionPicker など) に入る際、元の Scene を退避する先。
     /// exit_* 時に復元する。
     pub(crate) previous_scene: Option<Box<Scene>>,
+
+    /// 新しい release が GitHub 上に公開されていれば、その tag (v プレフィックス除去済み)。
+    pub update_available: Option<String>,
 }
 
 impl AppState {
@@ -228,6 +231,7 @@ impl AppState {
             keymap: Keymap::default_keymap(),
             scene: Scene::ProjectSelect,
             previous_scene: None,
+            update_available: None,
         }
     }
 
@@ -929,6 +933,10 @@ impl AppState {
             }
             AppEvent::CardDetailLoaded(Err(e)) => {
                 self.loading = LoadingState::Error(e);
+                Command::None
+            }
+            AppEvent::UpdateAvailable(version) => {
+                self.update_available = Some(version);
                 Command::None
             }
             AppEvent::Tick | AppEvent::Resize(_, _) => Command::None,
@@ -6588,5 +6596,14 @@ mod tests {
         let before = state.board_generation;
         state.start_loading_board("proj_1");
         assert_eq!(state.board_generation, before + 1);
+    }
+
+    #[test]
+    fn update_available_event_stores_version() {
+        let mut state = AppState::new(None);
+        assert_eq!(state.update_available, None);
+        let cmd = state.handle_event(AppEvent::UpdateAvailable("1.2.0".into()));
+        assert_eq!(state.update_available, Some("1.2.0".into()));
+        assert_eq!(cmd, Command::None);
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -233,7 +233,7 @@ pub async fn run(cmd: CliCommand, github: GitHubClient) -> anyhow::Result<()> {
         CliCommand::Assignee { action } => run_assignee(action, &github).await,
         CliCommand::Item { action } => run_item(action, &github).await,
         CliCommand::Skill => {
-            print!("{}", include_str!("../assets/skills.md"));
+            print!("{}", include_str!(concat!(env!("OUT_DIR"), "/skills.md")));
             Ok(())
         }
     }

--- a/src/event.rs
+++ b/src/event.rs
@@ -48,6 +48,8 @@ pub enum AppEvent {
     CommentsLoaded(Result<(String, Vec<Comment>), String>),
     SubIssuesLoaded(Result<(String, Vec<SubIssueRef>), String>),
     IssueDetailLoaded(Result<Box<Card>, String>),
+    /// 新しい release が GitHub 上にある場合の通知。値は最新バージョン (v プレフィックス除去済み)。
+    UpdateAvailable(String),
 }
 
 pub struct BoardPageData {

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -1,3 +1,4 @@
 pub mod client;
 mod convert;
 pub mod queries;
+pub mod update_check;

--- a/src/github/update_check.rs
+++ b/src/github/update_check.rs
@@ -1,0 +1,99 @@
+//! GitHub Releases API を使った最新リリースの確認。
+//!
+//! TUI 起動時にバックグラウンドで最新 release の tag を取得し、現在の
+//! `CARGO_PKG_VERSION` より新しければ `AppEvent::UpdateAvailable` を発火する。
+//! 認証不要 (public API) で、失敗はすべてサイレント無視。
+
+const RELEASES_URL: &str =
+    "https://api.github.com/repos/uzimaru0000/gh-board/releases/latest";
+
+/// 最新 release の tag を取得し、`v` プレフィックスを除去した version 文字列で返す。
+/// ネットワークエラーや JSON 解析失敗などは `None` を返す。
+pub async fn fetch_latest_version() -> Option<String> {
+    let resp = reqwest::Client::new()
+        .get(RELEASES_URL)
+        .header("User-Agent", "gh-board")
+        .header("Accept", "application/vnd.github+json")
+        .send()
+        .await
+        .ok()?;
+
+    if !resp.status().is_success() {
+        return None;
+    }
+
+    let json: serde_json::Value = resp.json().await.ok()?;
+    let tag = json.get("tag_name")?.as_str()?;
+    Some(strip_v_prefix(tag).to_string())
+}
+
+fn strip_v_prefix(tag: &str) -> &str {
+    tag.strip_prefix('v').unwrap_or(tag)
+}
+
+/// `latest` が `current` より新しいバージョンかを判定する。
+/// どちらかが `major.minor.patch` 形式として解析できない場合は `false`。
+pub fn is_newer(latest: &str, current: &str) -> bool {
+    match (parse_semver(latest), parse_semver(current)) {
+        (Some(l), Some(c)) => l > c,
+        _ => false,
+    }
+}
+
+fn parse_semver(s: &str) -> Option<(u32, u32, u32)> {
+    let core = s.split(['-', '+']).next().unwrap_or(s);
+    let parts: Vec<&str> = core.split('.').collect();
+    if parts.len() != 3 {
+        return None;
+    }
+    Some((parts[0].parse().ok()?, parts[1].parse().ok()?, parts[2].parse().ok()?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_v_prefix() {
+        assert_eq!(strip_v_prefix("v1.2.3"), "1.2.3");
+        assert_eq!(strip_v_prefix("1.2.3"), "1.2.3");
+        assert_eq!(strip_v_prefix("version-1"), "ersion-1");
+    }
+
+    #[test]
+    fn is_newer_detects_higher_patch() {
+        assert!(is_newer("1.0.1", "1.0.0"));
+    }
+
+    #[test]
+    fn is_newer_detects_higher_minor() {
+        assert!(is_newer("1.2.0", "1.1.99"));
+    }
+
+    #[test]
+    fn is_newer_detects_higher_major() {
+        assert!(is_newer("2.0.0", "1.99.99"));
+    }
+
+    #[test]
+    fn is_newer_false_on_equal() {
+        assert!(!is_newer("1.0.0", "1.0.0"));
+    }
+
+    #[test]
+    fn is_newer_false_on_older() {
+        assert!(!is_newer("0.9.0", "1.0.0"));
+    }
+
+    #[test]
+    fn is_newer_false_on_unparseable() {
+        assert!(!is_newer("abc", "1.0.0"));
+        assert!(!is_newer("1.0.0", "abc"));
+    }
+
+    #[test]
+    fn parse_semver_ignores_prerelease_suffix() {
+        assert_eq!(parse_semver("1.2.3-rc.1"), Some((1, 2, 3)));
+        assert_eq!(parse_semver("1.2.3+build.5"), Some((1, 2, 3)));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ use github::client::GitHubClient;
 use model::state::{LoadingState, Scene, ViewMode};
 
 #[derive(Parser)]
-#[command(name = "gh-board", about = "View GitHub Projects V2 as a kanban board")]
+#[command(name = "gh-board", about = "View GitHub Projects V2 as a kanban board", version)]
 struct Cli {
     #[command(subcommand)]
     command: Option<cli::CliCommand>,

--- a/src/ui/statusline.rs
+++ b/src/ui/statusline.rs
@@ -166,8 +166,11 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
     frame.render_widget(line, status_area);
 
     // 右端に loading status (アニメーション付き) を重ねて描画
-    if let Some(loading_line) = build_loading_line(&app.state.loading) {
-        let width = loading_line.width() as u16;
+    // loading が無いときに限り、update 通知を同じ位置に表示する
+    let right_line = build_loading_line(&app.state.loading)
+        .or_else(|| build_update_line(app.state.update_available.as_deref()));
+    if let Some(line) = right_line {
+        let width = line.width() as u16;
         if status_area.width >= width {
             let right_area = Rect {
                 x: status_area.x + status_area.width - width,
@@ -175,7 +178,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
                 width,
                 height: 1,
             };
-            frame.render_widget(loading_line.alignment(Alignment::Right), right_area);
+            frame.render_widget(line.alignment(Alignment::Right), right_area);
         }
     }
 }
@@ -191,6 +194,15 @@ pub(crate) fn loading_spinner_span(loading: &LoadingState) -> Option<Span<'stati
         }
         _ => None,
     }
+}
+
+fn build_update_line(update_available: Option<&str>) -> Option<Line<'static>> {
+    let v = update_available?;
+    let style = Style::default().fg(theme().text_muted);
+    Some(Line::from(vec![Span::styled(
+        format!("↑ v{v} available "),
+        style,
+    )]))
 }
 
 fn build_loading_line(loading: &LoadingState) -> Option<Line<'static>> {


### PR DESCRIPTION
## Summary

- **#62**: `gh board skill` が出力するドキュメントにバージョン情報を埋め込み、Claude が「手元 SKILL.md と `gh board --version` の不一致」を検知したら自動で `gh board skill > <path>` を実行して更新するよう指示を追加
- **#64**: TUI 起動時に GitHub Releases API で最新 tag を取得し、現在のバージョンより新しければステータスバー右端に `↑ vX.Y.Z available` を薄く表示 (失敗はサイレント無視)

両 issue は「バイナリ更新と手元 skill ファイルの同期」という観点で関連。#64 がユーザーにバイナリ更新を促し、その後 #62 の仕組みで skill ファイルも自動同期される、という流れを想定。

## Test plan

- [x] `cargo test` で全テスト通過 (349 既存 + 1 AppState + 8 update_check = 358)
- [x] `cargo clippy -- -D warnings` 警告ゼロ
- [x] `gh board --version` が `gh-board 1.0.0` を返す
- [x] `gh board skill | head` で frontmatter に `version: 1.0.0` + 自己更新指示が含まれる
- [x] Releases API (`https://api.github.com/repos/uzimaru0000/gh-board/releases/latest`) の疎通確認
- [ ] 意図的に Cargo.toml の version を下げて TUI を起動し、statusline に通知が出ることを確認 (reviewer での確認推奨)

🤖 Generated with [Claude Code](https://claude.com/claude-code)