### PR TITLE
feat: フィルタに no:/is:/-(NOT) 構文を追加 (#42)

### DIFF
--- a/src/model/state.rs
+++ b/src/model/state.rs
@@ -268,16 +268,72 @@ pub enum FilterCondition {
     Label(String),
     Assignee(String),
     Milestone(String),
+    /// `no:<field>` - 指定フィールドが未設定なカードにマッチ。
+    /// field は label / assignee(s) / milestone / custom field 名 (Status など)
+    No(String),
+    /// `is:<kind>` - カードの種別や状態でマッチ
+    Is(IsKind),
+    /// `-<cond>` - 条件の否定
+    Not(Box<FilterCondition>),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum IsKind {
+    Open,
+    Closed,
+    Merged,
+    Issue,
+    Pr,
+    Draft,
+}
+
+impl IsKind {
+    fn parse(s: &str) -> Option<Self> {
+        match s.to_ascii_lowercase().as_str() {
+            "open" => Some(IsKind::Open),
+            "closed" => Some(IsKind::Closed),
+            "merged" => Some(IsKind::Merged),
+            "issue" => Some(IsKind::Issue),
+            "pr" | "pull-request" | "pullrequest" => Some(IsKind::Pr),
+            "draft" | "draft-issue" => Some(IsKind::Draft),
+            _ => None,
+        }
+    }
+
+    fn as_query_value(&self) -> &'static str {
+        match self {
+            IsKind::Open => "open",
+            IsKind::Closed => "closed",
+            IsKind::Merged => "merged",
+            IsKind::Issue => "issue",
+            IsKind::Pr => "pr",
+            IsKind::Draft => "draft-issue",
+        }
+    }
 }
 
 impl FilterCondition {
     pub fn parse_token(token: &str) -> Self {
+        // `-<cond>` は否定。`--` や裸の `-` は通常テキスト扱い。
+        if let Some(rest) = token.strip_prefix('-')
+            && !rest.is_empty()
+            && !rest.starts_with('-')
+        {
+            return FilterCondition::Not(Box::new(FilterCondition::parse_token(rest)));
+        }
         if let Some(rest) = token.strip_prefix("label:") {
             FilterCondition::Label(rest.to_string())
         } else if let Some(rest) = token.strip_prefix("assignee:") {
             FilterCondition::Assignee(rest.to_string())
         } else if let Some(rest) = token.strip_prefix("milestone:") {
             FilterCondition::Milestone(rest.to_string())
+        } else if let Some(rest) = token.strip_prefix("no:") {
+            FilterCondition::No(rest.to_string())
+        } else if let Some(rest) = token.strip_prefix("is:") {
+            match IsKind::parse(rest) {
+                Some(kind) => FilterCondition::Is(kind),
+                None => FilterCondition::Text(token.to_string()),
+            }
         } else {
             FilterCondition::Text(token.to_string())
         }
@@ -294,6 +350,9 @@ impl FilterCondition {
                 format!("assignee:{}", quote_if_needed(stripped))
             }
             FilterCondition::Milestone(s) => format!("milestone:\"{s}\""),
+            FilterCondition::No(s) => format!("no:{}", quote_if_needed(s)),
+            FilterCondition::Is(kind) => format!("is:{}", kind.as_query_value()),
+            FilterCondition::Not(inner) => format!("-{}", inner.to_query_token()),
         }
     }
 
@@ -321,7 +380,63 @@ impl FilterCondition {
                     .as_ref()
                     .is_some_and(|m| m.to_lowercase().contains(&q))
             }
+            FilterCondition::No(field) => match field.to_ascii_lowercase().as_str() {
+                "label" | "labels" => card.labels.is_empty(),
+                "assignee" | "assignees" => card.assignees.is_empty(),
+                "milestone" => card.milestone.is_none(),
+                other => !card
+                    .custom_fields
+                    .iter()
+                    .any(|cf| field_name_of(cf).eq_ignore_ascii_case(other)),
+            },
+            FilterCondition::Is(kind) => match kind {
+                IsKind::Open => matches!(
+                    card.card_type,
+                    super::project::CardType::Issue {
+                        state: super::project::IssueState::Open
+                    } | super::project::CardType::PullRequest {
+                        state: super::project::PrState::Open
+                    }
+                ),
+                IsKind::Closed => matches!(
+                    card.card_type,
+                    super::project::CardType::Issue {
+                        state: super::project::IssueState::Closed
+                    } | super::project::CardType::PullRequest {
+                        state: super::project::PrState::Closed
+                            | super::project::PrState::Merged
+                    }
+                ),
+                IsKind::Merged => matches!(
+                    card.card_type,
+                    super::project::CardType::PullRequest {
+                        state: super::project::PrState::Merged
+                    }
+                ),
+                IsKind::Issue => {
+                    matches!(card.card_type, super::project::CardType::Issue { .. })
+                }
+                IsKind::Pr => matches!(
+                    card.card_type,
+                    super::project::CardType::PullRequest { .. }
+                ),
+                IsKind::Draft => {
+                    matches!(card.card_type, super::project::CardType::DraftIssue)
+                }
+            },
+            FilterCondition::Not(inner) => !inner.matches(card),
         }
+    }
+}
+
+fn field_name_of(cf: &super::project::CustomFieldValue) -> &str {
+    use super::project::CustomFieldValue::{Date, Iteration, Number, SingleSelect, Text};
+    match cf {
+        SingleSelect { field_name, .. }
+        | Text { field_name, .. }
+        | Number { field_name, .. }
+        | Date { field_name, .. }
+        | Iteration { field_name, .. } => field_name,
     }
 }
 
@@ -570,6 +685,232 @@ mod tests {
                 "label:\"bug\" assignee:alice".to_string(),
                 "label:\"enhancement\"".to_string(),
             ]
+        );
+    }
+
+    // ===== no:/is:/- (Not) プレフィックスの拡張 =====
+
+    use super::super::project::{
+        Card, CardType, CustomFieldValue, IssueState, Label as ProjectLabel, PrState,
+    };
+
+    fn card_defaults() -> Card {
+        Card {
+            item_id: "i".into(),
+            content_id: None,
+            title: "title".into(),
+            number: None,
+            card_type: CardType::DraftIssue,
+            assignees: vec![],
+            labels: vec![],
+            url: None,
+            body: None,
+            comments: vec![],
+            milestone: None,
+            custom_fields: vec![],
+            pr_status: None,
+            linked_prs: vec![],
+            reactions: vec![],
+            archived: false,
+            parent_issue: None,
+            sub_issues_summary: None,
+            sub_issues: vec![],
+        }
+    }
+
+    #[test]
+    fn test_parse_no_label() {
+        assert_eq!(
+            FilterCondition::parse_token("no:label"),
+            FilterCondition::No("label".into())
+        );
+    }
+
+    #[test]
+    fn test_parse_no_status_custom() {
+        assert_eq!(
+            FilterCondition::parse_token("no:status"),
+            FilterCondition::No("status".into())
+        );
+    }
+
+    #[test]
+    fn test_parse_is_open() {
+        assert_eq!(
+            FilterCondition::parse_token("is:open"),
+            FilterCondition::Is(IsKind::Open)
+        );
+    }
+
+    #[test]
+    fn test_parse_is_pr() {
+        assert_eq!(
+            FilterCondition::parse_token("is:pr"),
+            FilterCondition::Is(IsKind::Pr)
+        );
+    }
+
+    #[test]
+    fn test_parse_is_unknown_fallbacks_to_text() {
+        assert_eq!(
+            FilterCondition::parse_token("is:foo"),
+            FilterCondition::Text("is:foo".into())
+        );
+    }
+
+    #[test]
+    fn test_parse_not_label() {
+        assert_eq!(
+            FilterCondition::parse_token("-label:bug"),
+            FilterCondition::Not(Box::new(FilterCondition::Label("bug".into())))
+        );
+    }
+
+    #[test]
+    fn test_parse_not_no_assignee() {
+        assert_eq!(
+            FilterCondition::parse_token("-no:assignee"),
+            FilterCondition::Not(Box::new(FilterCondition::No("assignee".into())))
+        );
+    }
+
+    #[test]
+    fn test_parse_bare_dash_is_text() {
+        assert_eq!(
+            FilterCondition::parse_token("-"),
+            FilterCondition::Text("-".into())
+        );
+    }
+
+    #[test]
+    fn test_matches_no_label_when_empty() {
+        let card = card_defaults();
+        assert!(FilterCondition::No("label".into()).matches(&card));
+    }
+
+    #[test]
+    fn test_matches_no_label_false_when_has_label() {
+        let mut card = card_defaults();
+        card.labels.push(ProjectLabel {
+            id: "x".into(),
+            name: "bug".into(),
+            color: "000".into(),
+        });
+        assert!(!FilterCondition::No("label".into()).matches(&card));
+    }
+
+    #[test]
+    fn test_matches_no_assignee_plural_alias() {
+        let card = card_defaults();
+        assert!(FilterCondition::No("assignees".into()).matches(&card));
+    }
+
+    #[test]
+    fn test_matches_no_milestone() {
+        let card = card_defaults();
+        assert!(FilterCondition::No("milestone".into()).matches(&card));
+    }
+
+    #[test]
+    fn test_matches_no_custom_field_when_absent() {
+        let card = card_defaults();
+        assert!(FilterCondition::No("Status".into()).matches(&card));
+    }
+
+    #[test]
+    fn test_matches_no_custom_field_case_insensitive() {
+        let mut card = card_defaults();
+        card.custom_fields.push(CustomFieldValue::SingleSelect {
+            field_id: "f".into(),
+            field_name: "Status".into(),
+            option_id: "o".into(),
+            name: "Todo".into(),
+            color: None,
+        });
+        // 大文字小文字を無視して一致するので "no:status" では未設定とは判定しない
+        assert!(!FilterCondition::No("status".into()).matches(&card));
+    }
+
+    #[test]
+    fn test_matches_is_open_issue() {
+        let mut card = card_defaults();
+        card.card_type = CardType::Issue {
+            state: IssueState::Open,
+        };
+        assert!(FilterCondition::Is(IsKind::Open).matches(&card));
+        assert!(!FilterCondition::Is(IsKind::Closed).matches(&card));
+        assert!(FilterCondition::Is(IsKind::Issue).matches(&card));
+        assert!(!FilterCondition::Is(IsKind::Pr).matches(&card));
+    }
+
+    #[test]
+    fn test_matches_is_closed_merged_pr() {
+        let mut card = card_defaults();
+        card.card_type = CardType::PullRequest {
+            state: PrState::Merged,
+        };
+        // Merged は closed の一種として扱う (GitHub 検索構文と同様)
+        assert!(FilterCondition::Is(IsKind::Closed).matches(&card));
+        assert!(FilterCondition::Is(IsKind::Merged).matches(&card));
+        assert!(FilterCondition::Is(IsKind::Pr).matches(&card));
+        assert!(!FilterCondition::Is(IsKind::Open).matches(&card));
+    }
+
+    #[test]
+    fn test_matches_is_draft() {
+        let card = card_defaults();
+        assert!(FilterCondition::Is(IsKind::Draft).matches(&card));
+        assert!(!FilterCondition::Is(IsKind::Issue).matches(&card));
+    }
+
+    #[test]
+    fn test_matches_not_inverts() {
+        let mut card = card_defaults();
+        card.labels.push(ProjectLabel {
+            id: "x".into(),
+            name: "bug".into(),
+            color: "000".into(),
+        });
+        let cond = FilterCondition::Not(Box::new(FilterCondition::Label("bug".into())));
+        assert!(!cond.matches(&card));
+        let cond2 = FilterCondition::Not(Box::new(FilterCondition::Label("enhancement".into())));
+        assert!(cond2.matches(&card));
+    }
+
+    #[test]
+    fn test_to_query_token_no() {
+        assert_eq!(
+            FilterCondition::No("label".into()).to_query_token(),
+            "no:label"
+        );
+    }
+
+    #[test]
+    fn test_to_query_token_is() {
+        assert_eq!(
+            FilterCondition::Is(IsKind::Open).to_query_token(),
+            "is:open"
+        );
+        assert_eq!(
+            FilterCondition::Is(IsKind::Draft).to_query_token(),
+            "is:draft-issue"
+        );
+    }
+
+    #[test]
+    fn test_to_query_token_not() {
+        assert_eq!(
+            FilterCondition::Not(Box::new(FilterCondition::Label("bug".into()))).to_query_token(),
+            "-label:\"bug\""
+        );
+    }
+
+    #[test]
+    fn test_to_server_queries_with_new_ops() {
+        let f = ActiveFilter::parse("no:assignee is:open -label:wontfix");
+        assert_eq!(
+            f.to_server_queries(),
+            vec!["no:assignee is:open -label:\"wontfix\"".to_string()]
         );
     }
 }

--- a/src/ui/filter_bar.rs
+++ b/src/ui/filter_bar.rs
@@ -49,7 +49,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
     let after_span = Span::styled(rest, Style::default().fg(theme().text));
 
     let hint = Span::styled(
-        " (Enter:apply  Esc:cancel  label:  assignee:  milestone:  |:OR)",
+        " (Enter:apply  Esc:cancel  label:  assignee:  milestone:  no:  is:  -:NOT  |:OR)",
         Style::default().fg(theme().text_muted),
     );
 

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -86,7 +86,7 @@ pub fn render(frame: &mut Frame, area: Rect, keymap: &Keymap) {
         HelpEntry { action: Action::SwitchProject, description: "Switch project" },
         HelpEntry { action: Action::ChangeGrouping, description: "Change grouping field" },
         HelpEntry { action: Action::ToggleLayout, description: "Toggle layout (Board/Table/Roadmap)" },
-        HelpEntry { action: Action::StartFilter, description: "Filter (label: assignee: milestone: |:OR)" },
+        HelpEntry { action: Action::StartFilter, description: "Filter (label: assignee: milestone: no: is: -:NOT |:OR)" },
         HelpEntry { action: Action::ClearFilter, description: "Clear filter / view" },
         HelpEntry { action: Action::Refresh, description: "Refresh" },
         HelpEntry { action: Action::ShowHelp, description: "Toggle help" },


### PR DESCRIPTION
## Summary
- フィルタ DSL を GitHub 検索構文に寄せて拡張 (closes #42)
- `no:<field>` — label / assignee(s) / milestone / custom field 名 (`no:status` など)
- `is:<kind>` — open / closed / merged / issue / pr / draft
- `-<cond>` — 条件の否定 (例: `-label:wontfix`)
- サーバー側 query (`to_query_token`) にも同じ構文で変換するので初回フェッチからフィルタが効く

## Examples
```
is:open no:assignee
-label:wontfix
is:pr is:open | is:draft
no:status
```

## Test plan
- [x] `cargo test` (383 passed)
- [x] `cargo clippy --all-targets -- -D warnings`
- [ ] ボード上で `/is:open no:assignee` 等を手動で確認
- [ ] `no:status` で Status 未割り当てカードが残るのを確認
- [ ] `-label:xxx` で除外できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)