### PR TITLE
feat: 画面サイズが小さい端末向けのレスポンシブ対応 (#69)

### DIFF
--- a/src/ui/board.rs
+++ b/src/ui/board.rs
@@ -50,9 +50,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
     let end = (scroll_x + visible_cols).min(num_cols);
     let render_count = end - scroll_x;
 
-    let constraints: Vec<Constraint> = (0..render_count)
-        .map(|_| Constraint::Length(COLUMN_WIDTH))
-        .collect();
+    let constraints = column_constraints(render_count, area.width);
 
     let col_areas = Layout::horizontal(constraints).split(area);
 
@@ -207,6 +205,18 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
     }
 }
 
+/// 描画するカラム数と利用可能幅から horizontal Layout 用の Constraint 配列を返す。
+/// 表示可能カラムが 1 つだけの場合は全幅を埋めるように伸ばす (小さい端末向けレスポンシブ対応)。
+fn column_constraints(render_count: usize, total_width: u16) -> Vec<Constraint> {
+    if render_count == 1 {
+        vec![Constraint::Length(total_width)]
+    } else {
+        (0..render_count)
+            .map(|_| Constraint::Length(COLUMN_WIDTH))
+            .collect()
+    }
+}
+
 fn render_shadow(buf: &mut Buffer, card_area: Rect) {
     // 既存セルの文字を残しつつ色を暗くして透過風の影にする
     let shadow_fg = theme().shadow_fg;
@@ -229,5 +239,42 @@ fn render_shadow(buf: &mut Buffer, card_area: Rect) {
     let shadow_y = card_area.y + card_area.height;
     for dx in 1..=card_area.width {
         dim(buf, card_area.x + dx, shadow_y);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn column_constraints_single_column_uses_full_width() {
+        let cs = column_constraints(1, 120);
+        assert_eq!(cs, vec![Constraint::Length(120)]);
+    }
+
+    #[test]
+    fn column_constraints_single_column_on_narrow_screen() {
+        // 画面幅が COLUMN_WIDTH より狭くても、唯一のカラムは全幅を埋める
+        let cs = column_constraints(1, 20);
+        assert_eq!(cs, vec![Constraint::Length(20)]);
+    }
+
+    #[test]
+    fn column_constraints_multi_column_keeps_fixed_width() {
+        let cs = column_constraints(3, 200);
+        assert_eq!(
+            cs,
+            vec![
+                Constraint::Length(COLUMN_WIDTH),
+                Constraint::Length(COLUMN_WIDTH),
+                Constraint::Length(COLUMN_WIDTH),
+            ]
+        );
+    }
+
+    #[test]
+    fn column_constraints_zero_columns_is_empty() {
+        let cs = column_constraints(0, 120);
+        assert!(cs.is_empty());
     }
 }

--- a/src/ui/comment_list.rs
+++ b/src/ui/comment_list.rs
@@ -8,7 +8,7 @@ use ratatui::{
 
 use crate::app::App;
 use crate::app_state::AppState;
-use crate::ui::layout::centered_rect_pct;
+use crate::ui::layout::modal_area_pct;
 use crate::ui::scroll_fade::{draw_bottom_arrow, draw_top_arrow};
 use crate::ui::theme::theme;
 
@@ -23,7 +23,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
         None => return,
     };
 
-    let popup = centered_rect_pct(60, 70, area);
+    let popup = modal_area_pct(60, 70, area);
     frame.render_widget(Clear, popup);
 
     let total_comments = card.comments.len();

--- a/src/ui/confirm.rs
+++ b/src/ui/confirm.rs
@@ -7,11 +7,11 @@ use ratatui::{
 };
 
 use crate::model::state::{ConfirmAction, ConfirmState};
-use crate::ui::layout::centered_rect_fixed;
+use crate::ui::layout::modal_area_fixed;
 use crate::ui::theme::theme;
 
 pub fn render(frame: &mut Frame, area: Rect, state: &ConfirmState) {
-    let popup = centered_rect_fixed(50, 7, area);
+    let popup = modal_area_fixed(50, 7, area);
     frame.render_widget(Clear, popup);
 
     let accent = match state.action {

--- a/src/ui/create_card.rs
+++ b/src/ui/create_card.rs
@@ -7,11 +7,11 @@ use ratatui::{
 };
 
 use crate::model::state::{CreateCardField, CreateCardState, NewCardType};
-use crate::ui::layout::centered_rect_fixed;
+use crate::ui::layout::modal_area_fixed;
 use crate::ui::theme::theme;
 
 pub fn render(frame: &mut Frame, area: Rect, state: &CreateCardState) {
-    let popup = centered_rect_fixed(60, 21, area);
+    let popup = modal_area_fixed(60, 21, area);
     frame.render_widget(Clear, popup);
 
     let block = Block::default()

--- a/src/ui/detail/mod.rs
+++ b/src/ui/detail/mod.rs
@@ -19,7 +19,7 @@ use crate::app::App;
 use crate::app_state::AppState;
 use crate::model::project::{Card, CardType, IssueState, PrState, ReactionSummary};
 use crate::model::state::DetailPane;
-use crate::ui::layout::centered_rect_pct;
+use crate::ui::layout::modal_area_pct;
 use crate::ui::scroll_fade::{draw_bottom_arrow, draw_left_arrow, draw_right_arrow, draw_top_arrow};
 use crate::ui::theme::theme;
 
@@ -29,7 +29,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
         None => return,
     };
 
-    let popup = centered_rect_pct(80, 80, area);
+    let popup = modal_area_pct(80, 80, area);
     frame.render_widget(Clear, popup);
 
     // Fix: ポップアップ左境界をまたぐ全角文字をクリア

--- a/src/ui/edit_card.rs
+++ b/src/ui/edit_card.rs
@@ -7,11 +7,11 @@ use ratatui::{
 };
 
 use crate::model::state::{EditCardField, EditCardState};
-use crate::ui::layout::centered_rect_fixed;
+use crate::ui::layout::modal_area_fixed;
 use crate::ui::theme::theme;
 
 pub fn render(frame: &mut Frame, area: Rect, state: &EditCardState) {
-    let popup = centered_rect_fixed(60, 14, area);
+    let popup = modal_area_fixed(60, 14, area);
     frame.render_widget(Clear, popup);
 
     let block = Block::default()

--- a/src/ui/group_by_select.rs
+++ b/src/ui/group_by_select.rs
@@ -8,7 +8,7 @@ use ratatui::{
 
 use crate::app::App;
 use crate::model::project::Grouping;
-use crate::ui::layout::centered_rect_pct;
+use crate::ui::layout::modal_area_pct;
 use crate::ui::theme::theme;
 
 pub fn render(frame: &mut Frame, area: Rect, app: &App) {
@@ -19,7 +19,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
 
     let current = app.state.board.as_ref().map(|b| &b.grouping);
 
-    let popup = centered_rect_pct(50, 60, area);
+    let popup = modal_area_pct(50, 60, area);
     frame.render_widget(Clear, popup);
 
     let block = Block::default()

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -8,7 +8,7 @@ use ratatui::{
 
 use crate::action::Action;
 use crate::keymap::{KeyBind, Keymap, KeymapMode};
-use crate::ui::layout::centered_rect_pct;
+use crate::ui::layout::modal_area_pct;
 use crate::ui::theme::theme;
 
 /// Format a list of KeyBinds into a display string like "j ↓"
@@ -40,7 +40,7 @@ struct HelpEntry {
 }
 
 pub fn render(frame: &mut Frame, area: Rect, keymap: &Keymap) {
-    let popup = centered_rect_pct(50, 70, area);
+    let popup = modal_area_pct(50, 70, area);
     frame.render_widget(Clear, popup);
 
     let block = Block::default()

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -1,5 +1,39 @@
 use ratatui::layout::{Constraint, Flex, Layout, Rect};
 
+use crate::ui::board::COLUMN_WIDTH;
+
+/// コンパクトレイアウトと判定する高さの下限 (行数)。
+/// 80%×80% のモーダルが詳細を出すのに手狭になる境目。
+pub const COMPACT_HEIGHT: u16 = 24;
+
+/// 端末サイズが小さく、モーダルや複数カラムでは窮屈になる状態かどうか。
+/// カンバンのカラムが 1 つしか収まらない幅、もしくは高さが極端に低い場合に true。
+pub fn is_compact(area: Rect) -> bool {
+    area.width < COLUMN_WIDTH * 2 || area.height < COMPACT_HEIGHT
+}
+
+/// モーダル/ポップアップの描画領域 (パーセント指定版)。
+/// compact な端末サイズでは親 area を丸ごと使い (全画面化)、それ以外では
+/// 指定パーセントの中央寄せ矩形を返す。
+pub fn modal_area_pct(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
+    if is_compact(area) {
+        area
+    } else {
+        centered_rect_pct(percent_x, percent_y, area)
+    }
+}
+
+/// モーダル/ポップアップの描画領域 (固定高さ版)。
+/// compact な端末サイズでは親 area を丸ごと使い (全画面化)、それ以外では
+/// 指定パーセント幅 × 固定高さの中央寄せ矩形を返す。
+pub fn modal_area_fixed(percent_x: u16, height: u16, area: Rect) -> Rect {
+    if is_compact(area) {
+        area
+    } else {
+        centered_rect_fixed(percent_x, height, area)
+    }
+}
+
 pub fn centered_rect_pct(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
     let vertical = Layout::vertical([Constraint::Percentage(percent_y)])
         .flex(Flex::Center)
@@ -16,4 +50,71 @@ pub fn centered_rect_fixed(percent_x: u16, height: u16, area: Rect) -> Rect {
     Layout::horizontal([Constraint::Percentage(percent_x)])
         .flex(Flex::Center)
         .split(vertical[0])[0]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rect(w: u16, h: u16) -> Rect {
+        Rect {
+            x: 0,
+            y: 0,
+            width: w,
+            height: h,
+        }
+    }
+
+    #[test]
+    fn is_compact_narrow_width() {
+        // カラム 1 つしか収まらない幅 (COLUMN_WIDTH * 2 未満) は compact
+        assert!(is_compact(rect(COLUMN_WIDTH * 2 - 1, 40)));
+        assert!(is_compact(rect(COLUMN_WIDTH, 40)));
+    }
+
+    #[test]
+    fn is_compact_wide_enough() {
+        // 2 カラム分以上の幅かつ十分な高さなら compact ではない
+        assert!(!is_compact(rect(COLUMN_WIDTH * 2, COMPACT_HEIGHT)));
+        assert!(!is_compact(rect(120, 40)));
+    }
+
+    #[test]
+    fn is_compact_short_height() {
+        // 高さが極端に低い場合は compact
+        assert!(is_compact(rect(120, COMPACT_HEIGHT - 1)));
+        assert!(is_compact(rect(120, 10)));
+    }
+
+    #[test]
+    fn modal_area_pct_compact_is_fullscreen() {
+        let area = rect(50, 20);
+        assert_eq!(modal_area_pct(80, 80, area), area);
+        assert_eq!(modal_area_pct(60, 60, area), area);
+    }
+
+    #[test]
+    fn modal_area_pct_wide_returns_centered() {
+        let area = rect(100, 40);
+        let popup = modal_area_pct(80, 80, area);
+        assert_ne!(popup, area);
+        assert_eq!(popup.width, 80);
+        assert_eq!(popup.height, 32);
+    }
+
+    #[test]
+    fn modal_area_fixed_compact_is_fullscreen() {
+        let area = rect(50, 20);
+        // compact のときは固定高さ指定も無視して全画面
+        assert_eq!(modal_area_fixed(60, 10, area), area);
+    }
+
+    #[test]
+    fn modal_area_fixed_wide_uses_fixed_height() {
+        let area = rect(100, 40);
+        let popup = modal_area_fixed(60, 10, area);
+        assert_ne!(popup, area);
+        assert_eq!(popup.width, 60);
+        assert_eq!(popup.height, 10);
+    }
 }

--- a/src/ui/project_list.rs
+++ b/src/ui/project_list.rs
@@ -8,12 +8,12 @@ use ratatui::{
 
 use crate::app::App;
 use crate::app_state::AppState;
-use crate::ui::layout::centered_rect_pct;
+use crate::ui::layout::modal_area_pct;
 use crate::ui::scroll_fade::{draw_bottom_arrow, draw_top_arrow};
 use crate::ui::theme::theme;
 
 pub fn render(frame: &mut Frame, area: Rect, app: &App) {
-    let popup_area = centered_rect_pct(60, 60, area);
+    let popup_area = modal_area_pct(60, 60, area);
 
     frame.render_widget(Clear, popup_area);
 

--- a/src/ui/reaction_picker.rs
+++ b/src/ui/reaction_picker.rs
@@ -9,11 +9,11 @@ use ratatui::{
 use crate::app::App;
 use crate::model::project::{ReactionContent, ReactionSummary};
 use crate::model::state::{ReactionPickerState, ReactionTarget};
-use crate::ui::layout::centered_rect_fixed;
+use crate::ui::layout::modal_area_fixed;
 use crate::ui::theme::theme;
 
 pub fn render(frame: &mut Frame, area: Rect, state: &ReactionPickerState, app: &App) {
-    let popup = centered_rect_fixed(48, 7, area);
+    let popup = modal_area_fixed(48, 7, area);
     frame.render_widget(Clear, popup);
 
     let block = Block::default()

--- a/src/ui/repo_select.rs
+++ b/src/ui/repo_select.rs
@@ -8,12 +8,12 @@ use ratatui::{
 
 use crate::model::project::Repository;
 use crate::model::state::RepoSelectState;
-use crate::ui::layout::centered_rect_fixed;
+use crate::ui::layout::modal_area_fixed;
 use crate::ui::theme::theme;
 
 pub fn render(frame: &mut Frame, area: Rect, repos: &[Repository], state: &RepoSelectState) {
     let height = (repos.len() as u16 + 4).min(20);
-    let popup = centered_rect_fixed(50, height, area);
+    let popup = modal_area_fixed(50, height, area);
     frame.render_widget(Clear, popup);
 
     let block = Block::default()


### PR DESCRIPTION
## Summary
画面が狭いときに UI が窮屈になる問題を解消 (closes #69)

- `is_compact(area)` — 幅 `COLUMN_WIDTH * 2 = 72` 未満、または高さ `24` 未満を compact 判定
- `modal_area_pct` / `modal_area_fixed` — compact 時は親 area を全画面として使い、通常時は中央寄せモーダル
- 全モーダルを新ヘルパーへ切り替え: Detail / Create / Edit / ProjectList / CommentList / ReactionPicker / Confirm / Help / RepoSelect / GroupBySelect
- Board: 表示可能カラムが 1 つのときはカラムを画面幅いっぱいに広げる

## Test plan
- [x] `cargo test` (394 passed)
- [x] `cargo clippy --all-targets -- -D warnings`
- [ ] 狭い端末 (幅 < 72) でボード / 詳細 / 作成モーダル / ヘルプ等が全画面になることを目視確認
- [ ] 通常サイズでモーダルが従来どおり中央寄せになることを確認
- [ ] カラム 1 つだけ見える状態でカラムが全幅に広がることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)