### PR TITLE
fix: Card 作成/編集モーダルの Title 入力欄に横 padding を追加 (#45)

### DIFF
--- a/src/ui/create_card.rs
+++ b/src/ui/create_card.rs
@@ -71,7 +71,8 @@ pub fn render(frame: &mut Frame, area: Rect, state: &CreateCardState) {
         .title(Span::styled(" Title ", title_label_style))
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .border_style(title_border_style);
+        .border_style(title_border_style)
+        .padding(Padding::horizontal(1));
 
     let title_inner = title_block.inner(chunks[2]);
     frame.render_widget(title_block, chunks[2]);

--- a/src/ui/create_card.rs
+++ b/src/ui/create_card.rs
@@ -67,15 +67,19 @@ pub fn render(frame: &mut Frame, area: Rect, state: &CreateCardState) {
     };
     let title_label_style = if title_is_active { active_label } else { label_style };
 
+    // Submit ボタンと同じく外側に 1 col の余白を取り、縦ラインを揃える
+    let title_outer = Block::default().padding(Padding::horizontal(1));
+    let title_area = title_outer.inner(chunks[2]);
+    frame.render_widget(title_outer, chunks[2]);
+
     let title_block = Block::default()
         .title(Span::styled(" Title ", title_label_style))
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .border_style(title_border_style)
-        .padding(Padding::horizontal(1));
+        .border_style(title_border_style);
 
-    let title_inner = title_block.inner(chunks[2]);
-    frame.render_widget(title_block, chunks[2]);
+    let title_inner = title_block.inner(title_area);
+    frame.render_widget(title_block, title_area);
 
     let title_line = render_title_content(&state.title_input, state.title_cursor, title_is_active, input_style);
     frame.render_widget(Paragraph::new(title_line), title_inner);

--- a/src/ui/edit_card.rs
+++ b/src/ui/edit_card.rs
@@ -59,15 +59,19 @@ pub fn render(frame: &mut Frame, area: Rect, state: &EditCardState) {
         label_style
     };
 
+    // 縦ラインを他フィールドと揃えるため外側に 1 col の余白を取る
+    let title_outer = Block::default().padding(Padding::horizontal(1));
+    let title_area = title_outer.inner(chunks[0]);
+    frame.render_widget(title_outer, chunks[0]);
+
     let title_block = Block::default()
         .title(Span::styled(" Title ", title_label_style))
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .border_style(title_border_style)
-        .padding(Padding::horizontal(1));
+        .border_style(title_border_style);
 
-    let title_inner = title_block.inner(chunks[0]);
-    frame.render_widget(title_block, chunks[0]);
+    let title_inner = title_block.inner(title_area);
+    frame.render_widget(title_block, title_area);
 
     let title_line = render_title_content(
         &state.title_input,

--- a/src/ui/edit_card.rs
+++ b/src/ui/edit_card.rs
@@ -2,7 +2,7 @@ use ratatui::{
     layout::{Constraint, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, BorderType, Borders, Clear, Paragraph},
+    widgets::{Block, BorderType, Borders, Clear, Padding, Paragraph},
     Frame,
 };
 
@@ -63,7 +63,8 @@ pub fn render(frame: &mut Frame, area: Rect, state: &EditCardState) {
         .title(Span::styled(" Title ", title_label_style))
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .border_style(title_border_style);
+        .border_style(title_border_style)
+        .padding(Padding::horizontal(1));
 
     let title_inner = title_block.inner(chunks[0]);
     frame.render_widget(title_block, chunks[0]);


### PR DESCRIPTION
## Summary
- Card 作成モーダル (#45) と Card 編集モーダルの Title 入力欄のボーダー直下に文字が貼り付いて見える問題を修正
- 両方の Title ブロックに `Padding::horizontal(1)` を追加
- closes #45

## Before / After
Before: \`╭ Title ────╮\` の直下に \`│text      │\` と文字が左ボーダーと接触
After: \`│ text     │\` と 1 col 空けて表示

## Test plan
- [x] \`cargo test\` (394 passed)
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [ ] \`n\` で Card 作成モーダルを開き、Title 入力欄の左右に 1 col の余白が出ることを確認
- [ ] Card 編集モーダルでも同様に確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)