### PR TITLE
feat: バルク操作モードを追加 (#54)

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -52,4 +52,13 @@ pub enum Action {
     // Reactions
     OpenReactionPicker,
     ToggleReaction,
+
+    // Bulk selection
+    BulkSelectStart,
+    BulkSelectToggle,
+    BulkSelectAll,
+    BulkSelectClear,
+    BulkArchive,
+    BulkMoveLeft,
+    BulkMoveRight,
 }

--- a/src/app_state/bulk.rs
+++ b/src/app_state/bulk.rs
@@ -1,0 +1,521 @@
+use super::*;
+use crate::command::CustomFieldValueInput;
+use crate::model::project::Grouping;
+
+impl AppState {
+    pub(super) fn enter_bulk_select(&mut self) {
+        self.bulk_selected.clear();
+        self.mode = ViewMode::BulkSelect;
+        self.scene = Scene::BulkSelect;
+    }
+
+    pub(super) fn exit_bulk_select(&mut self) {
+        self.bulk_selected.clear();
+        self.mode = ViewMode::Board;
+        self.scene = scene_from_mode_tag(&self.mode);
+    }
+
+    /// 現在選択中のカードを bulk_selected に追加/削除する。
+    /// フィルタ適用時は real_card_index() 経由で実カードを参照する。
+    /// Table layout では table_selected_row を基準に解決する。
+    pub(super) fn bulk_toggle_current_card(&mut self) {
+        let Some(item_id) = self.current_card_item_id() else {
+            return;
+        };
+        if !self.bulk_selected.remove(&item_id) {
+            self.bulk_selected.insert(item_id);
+        }
+    }
+
+    /// 現在のカーソル位置にあるカードの item_id を返す (layout 対応)。
+    fn current_card_item_id(&self) -> Option<String> {
+        let board = self.board.as_ref()?;
+        if self.current_layout == LayoutMode::Table {
+            let rows = self.table_rows();
+            let (ci, ri) = *rows.get(self.table_selected_row)?;
+            return board
+                .columns
+                .get(ci)
+                .and_then(|c| c.cards.get(ri))
+                .map(|card| card.item_id.clone());
+        }
+        let real_idx = self.real_card_index()?;
+        board
+            .columns
+            .get(self.selected_column)
+            .and_then(|c| c.cards.get(real_idx))
+            .map(|card| card.item_id.clone())
+    }
+
+    /// 現在の表示範囲 (Board ならカラム、Table なら全行) の全カードを bulk_selected に追加。
+    pub(super) fn bulk_select_current_column(&mut self) {
+        let Some(board) = &self.board else {
+            return;
+        };
+        if self.current_layout == LayoutMode::Table {
+            let rows = self.table_rows();
+            for (ci, ri) in rows {
+                if let Some(card) = board.columns.get(ci).and_then(|c| c.cards.get(ri)) {
+                    self.bulk_selected.insert(card.item_id.clone());
+                }
+            }
+            return;
+        }
+        let Some(col) = board.columns.get(self.selected_column) else {
+            return;
+        };
+        for card in &col.cards {
+            if self
+                .filter
+                .active_filter
+                .as_ref()
+                .is_none_or(|f| f.matches(card))
+            {
+                self.bulk_selected.insert(card.item_id.clone());
+            }
+        }
+    }
+
+    /// BulkArchive を Confirm 経由で発行するための遷移。
+    /// 選択が空なら何もしない。確定時には Batch(ArchiveCard ...) が発行される。
+    pub(super) fn start_bulk_archive(&mut self) {
+        if self.bulk_selected.is_empty() {
+            return;
+        }
+        let item_ids: Vec<String> = self.bulk_selected.iter().cloned().collect();
+        let title = format!("{} cards", item_ids.len());
+        self.enter_confirm(ConfirmState {
+            action: ConfirmAction::ArchiveMultipleCards { item_ids },
+            title,
+            return_to: ViewMode::Board,
+        });
+    }
+
+    /// 選択済みカードを target_column に一括で移動する。
+    /// grouping が SingleSelect でない場合は no-op。
+    /// 楽観的に board を書き換え、Batch(MoveCard ...) を返す。
+    pub(super) fn bulk_move_selected_to(&mut self, direction: BulkMoveDirection) -> Command {
+        if self.bulk_selected.is_empty() {
+            return Command::None;
+        }
+        let Some(project_id) = self.current_project.as_ref().map(|p| p.id.clone()) else {
+            return Command::None;
+        };
+        let board = match &self.board {
+            Some(b) => b,
+            None => return Command::None,
+        };
+        let (field_id, _) = match &board.grouping {
+            Grouping::SingleSelect {
+                field_id,
+                field_name,
+            } => (field_id.clone(), field_name.clone()),
+            _ => return Command::None,
+        };
+
+        // 現在の各カードのカラムを走査し、隣接カラムへの移動先 option_id を解決する。
+        // "No <field>" (空 option_id) には移動しない。
+        let mut moves: Vec<(String, String)> = Vec::new();
+        let board_mut = self.board.as_mut().unwrap();
+        // HashSet は順序未定義なので、items を一度 Vec にスナップショット
+        let targets: Vec<String> = self.bulk_selected.iter().cloned().collect();
+        for item_id in &targets {
+            let Some((src_col, card_idx)) = find_card_position(board_mut, item_id) else {
+                continue;
+            };
+            let target_col = match direction {
+                BulkMoveDirection::Left if src_col > 0 => src_col - 1,
+                BulkMoveDirection::Right if src_col + 1 < board_mut.columns.len() => src_col + 1,
+                _ => continue,
+            };
+            let target_option_id = board_mut.columns[target_col].option_id.clone();
+            if target_option_id.is_empty() {
+                continue;
+            }
+            // 楽観的更新: カードを移動 + custom_fields の Status を書き換え
+            let mut card = board_mut.columns[src_col].cards.remove(card_idx);
+            card.custom_fields.retain(|fv| fv.field_id() != field_id);
+            if let Grouping::SingleSelect {
+                field_id: fid,
+                field_name: fname,
+            } = &board_mut.grouping
+            {
+                let (name, color) = board_mut
+                    .field_definitions
+                    .iter()
+                    .find_map(|d| match d {
+                        FieldDefinition::SingleSelect { id, options, .. } if id == fid => options
+                            .iter()
+                            .find(|o| o.id == target_option_id)
+                            .map(|o| (o.name.clone(), o.color.clone())),
+                        _ => None,
+                    })
+                    .unwrap_or_default();
+                card.custom_fields.push(CustomFieldValue::SingleSelect {
+                    field_id: fid.clone(),
+                    field_name: fname.clone(),
+                    option_id: target_option_id.clone(),
+                    name,
+                    color,
+                });
+            }
+            board_mut.columns[target_col].cards.push(card);
+            moves.push((item_id.clone(), target_option_id));
+        }
+
+        if moves.is_empty() {
+            return Command::None;
+        }
+
+        let cmds: Vec<Command> = moves
+            .into_iter()
+            .map(|(item_id, option_id)| Command::MoveCard {
+                project_id: project_id.clone(),
+                item_id,
+                field_id: field_id.clone(),
+                value: CustomFieldValueInput::SingleSelect { option_id },
+            })
+            .collect();
+        if cmds.len() == 1 {
+            cmds.into_iter().next().unwrap()
+        } else {
+            Command::Batch(cmds)
+        }
+    }
+
+    pub(super) fn handle_bulk_select_key(&mut self, key: KeyEvent) -> Command {
+        let action = match self.keymap.resolve(KeymapMode::BulkSelect, &key) {
+            Some(a) => a,
+            None => return Command::None,
+        };
+
+        // ForceQuit は global で解決されるがここでも明示
+        if matches!(action, Action::ForceQuit) {
+            self.should_quit = true;
+            return Command::None;
+        }
+
+        let is_table = self.current_layout == LayoutMode::Table;
+        let current_col_len = self.filtered_card_indices(self.selected_column).len();
+        let col_count = self.board.as_ref().map(|b| b.columns.len()).unwrap_or(0);
+        let row_count = if is_table { self.table_rows().len() } else { 0 };
+
+        match action {
+            Action::MoveDown => {
+                if is_table {
+                    if row_count > 0 {
+                        self.table_selected_row =
+                            (self.table_selected_row + 1).min(row_count - 1);
+                    }
+                } else if current_col_len > 0 {
+                    self.selected_card = (self.selected_card + 1).min(current_col_len - 1);
+                }
+                Command::None
+            }
+            Action::MoveUp => {
+                if is_table {
+                    self.table_selected_row = self.table_selected_row.saturating_sub(1);
+                } else {
+                    self.selected_card = self.selected_card.saturating_sub(1);
+                }
+                Command::None
+            }
+            Action::MoveLeft => {
+                if !is_table && self.selected_column > 0 {
+                    self.selected_column -= 1;
+                    self.clamp_card_selection();
+                }
+                Command::None
+            }
+            Action::MoveRight => {
+                if !is_table && col_count > 0 && self.selected_column + 1 < col_count {
+                    self.selected_column += 1;
+                    self.clamp_card_selection();
+                }
+                Command::None
+            }
+            Action::BulkSelectToggle => {
+                self.bulk_toggle_current_card();
+                Command::None
+            }
+            Action::BulkSelectAll => {
+                self.bulk_select_current_column();
+                Command::None
+            }
+            Action::BulkSelectClear => {
+                self.exit_bulk_select();
+                Command::None
+            }
+            Action::BulkArchive => {
+                self.start_bulk_archive();
+                Command::None
+            }
+            Action::BulkMoveLeft => {
+                let cmd = self.bulk_move_selected_to(BulkMoveDirection::Left);
+                // 選択解除 + BulkSelect のまま維持 (複数段階の操作を可能に)
+                self.bulk_selected.clear();
+                cmd
+            }
+            Action::BulkMoveRight => {
+                let cmd = self.bulk_move_selected_to(BulkMoveDirection::Right);
+                self.bulk_selected.clear();
+                cmd
+            }
+            _ => Command::None,
+        }
+    }
+
+    /// 選択済みカードを一括アーカイブする Command を構築する (Confirm 確定時に呼ぶ)。
+    /// 楽観的に board からも削除する。
+    pub(super) fn archive_multiple_cards(&mut self, item_ids: &[String]) -> Command {
+        let Some(project_id) = self.current_project.as_ref().map(|p| p.id.clone()) else {
+            return Command::None;
+        };
+        if let Some(board) = &mut self.board {
+            for item_id in item_ids {
+                for col in &mut board.columns {
+                    if let Some(pos) = col.cards.iter().position(|c| c.item_id == *item_id) {
+                        col.cards.remove(pos);
+                        break;
+                    }
+                }
+            }
+        }
+        self.clamp_card_selection();
+        self.bulk_selected.clear();
+
+        let cmds: Vec<Command> = item_ids
+            .iter()
+            .map(|item_id| Command::ArchiveCard {
+                project_id: project_id.clone(),
+                item_id: item_id.clone(),
+            })
+            .collect();
+        if cmds.is_empty() {
+            Command::None
+        } else if cmds.len() == 1 {
+            cmds.into_iter().next().unwrap()
+        } else {
+            Command::Batch(cmds)
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum BulkMoveDirection {
+    Left,
+    Right,
+}
+
+fn find_card_position(board: &Board, item_id: &str) -> Option<(usize, usize)> {
+    for (ci, col) in board.columns.iter().enumerate() {
+        if let Some(idx) = col.cards.iter().position(|c| c.item_id == item_id) {
+            return Some((ci, idx));
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::project::{Card, CardType, Column, ColumnColor, FieldDefinition, Grouping, SingleSelectOption};
+    use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent {
+            code,
+            modifiers: KeyModifiers::NONE,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::NONE,
+        }
+    }
+
+    fn key_shift(c: char) -> KeyEvent {
+        KeyEvent {
+            code: KeyCode::Char(c),
+            modifiers: KeyModifiers::NONE,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::NONE,
+        }
+    }
+
+    fn make_card(item_id: &str) -> Card {
+        Card {
+            item_id: item_id.into(),
+            content_id: None,
+            title: format!("card-{item_id}"),
+            number: None,
+            card_type: CardType::DraftIssue,
+            assignees: vec![],
+            labels: vec![],
+            url: None,
+            body: None,
+            comments: vec![],
+            milestone: None,
+            custom_fields: vec![],
+            pr_status: None,
+            linked_prs: vec![],
+            reactions: vec![],
+            archived: false,
+            parent_issue: None,
+            sub_issues_summary: None,
+            sub_issues: vec![],
+        }
+    }
+
+    fn make_board() -> Board {
+        Board {
+            project_title: "p".into(),
+            grouping: Grouping::SingleSelect {
+                field_id: "F".into(),
+                field_name: "Status".into(),
+            },
+            columns: vec![
+                Column {
+                    option_id: "todo".into(),
+                    name: "Todo".into(),
+                    color: Some(ColumnColor::Green),
+                    cards: vec![make_card("a"), make_card("b"), make_card("c")],
+                },
+                Column {
+                    option_id: "doing".into(),
+                    name: "Doing".into(),
+                    color: Some(ColumnColor::Yellow),
+                    cards: vec![make_card("d")],
+                },
+            ],
+            repositories: vec![],
+            field_definitions: vec![FieldDefinition::SingleSelect {
+                id: "F".into(),
+                name: "Status".into(),
+                options: vec![
+                    SingleSelectOption {
+                        id: "todo".into(),
+                        name: "Todo".into(),
+                        color: Some(ColumnColor::Green),
+                    },
+                    SingleSelectOption {
+                        id: "doing".into(),
+                        name: "Doing".into(),
+                        color: Some(ColumnColor::Yellow),
+                    },
+                ],
+            }],
+        }
+    }
+
+    fn make_state() -> AppState {
+        let mut state = AppState::new(None);
+        state.board = Some(make_board());
+        state.current_project = Some(crate::model::project::ProjectSummary {
+            id: "PRJ".into(),
+            title: "p".into(),
+            number: 1,
+            description: None,
+            url: "https://example.com/projects/1".into(),
+        });
+        state.mode = ViewMode::Board;
+        state
+    }
+
+    #[test]
+    fn bulk_select_start_enters_mode_and_resets() {
+        let mut state = make_state();
+        state.bulk_selected.insert("stale".into());
+        state.enter_bulk_select();
+        assert_eq!(state.mode, ViewMode::BulkSelect);
+        assert!(state.bulk_selected.is_empty());
+    }
+
+    #[test]
+    fn bulk_select_toggle_adds_and_removes() {
+        let mut state = make_state();
+        state.enter_bulk_select();
+        state.selected_column = 0;
+        state.selected_card = 0;
+        let cmd = state.handle_bulk_select_key(key(KeyCode::Char(' ')));
+        assert_eq!(cmd, Command::None);
+        assert!(state.bulk_selected.contains("a"));
+
+        // もう一度 Space → 解除
+        let _ = state.handle_bulk_select_key(key(KeyCode::Char(' ')));
+        assert!(!state.bulk_selected.contains("a"));
+    }
+
+    #[test]
+    fn bulk_select_movement_works() {
+        let mut state = make_state();
+        state.enter_bulk_select();
+        state.selected_column = 0;
+        state.selected_card = 0;
+        let _ = state.handle_bulk_select_key(key(KeyCode::Char('j')));
+        assert_eq!(state.selected_card, 1);
+        let _ = state.handle_bulk_select_key(key(KeyCode::Char('l')));
+        assert_eq!(state.selected_column, 1);
+    }
+
+    #[test]
+    fn bulk_select_clear_returns_to_board() {
+        let mut state = make_state();
+        state.enter_bulk_select();
+        state.bulk_selected.insert("a".into());
+        let _ = state.handle_bulk_select_key(key(KeyCode::Esc));
+        assert_eq!(state.mode, ViewMode::Board);
+        assert!(state.bulk_selected.is_empty());
+    }
+
+    #[test]
+    fn bulk_select_all_selects_current_column() {
+        let mut state = make_state();
+        state.enter_bulk_select();
+        state.selected_column = 0;
+        let _ = state.handle_bulk_select_key(key(KeyCode::Char('*')));
+        assert_eq!(state.bulk_selected.len(), 3);
+        assert!(state.bulk_selected.contains("a"));
+        assert!(state.bulk_selected.contains("b"));
+        assert!(state.bulk_selected.contains("c"));
+    }
+
+    #[test]
+    fn bulk_move_right_emits_move_commands_and_updates_board() {
+        let mut state = make_state();
+        state.enter_bulk_select();
+        state.bulk_selected.insert("a".into());
+        state.bulk_selected.insert("b".into());
+        let cmd = state.handle_bulk_select_key(key_shift('L'));
+        // 楽観的に board から移動済み
+        let board = state.board.as_ref().unwrap();
+        let todo = &board.columns[0].cards;
+        let doing = &board.columns[1].cards;
+        assert!(todo.iter().all(|c| c.item_id != "a" && c.item_id != "b"));
+        assert_eq!(doing.len(), 3); // d + a + b
+        // Command は Batch(MoveCard x 2) もしくは MoveCard (1 件の場合)
+        match cmd {
+            Command::Batch(cmds) => assert_eq!(cmds.len(), 2),
+            _ => panic!("expected Batch"),
+        }
+        // 選択はクリアされる
+        assert!(state.bulk_selected.is_empty());
+    }
+
+    #[test]
+    fn bulk_move_left_skips_when_no_left_column() {
+        let mut state = make_state();
+        state.enter_bulk_select();
+        state.bulk_selected.insert("a".into()); // すでに Todo (一番左)
+        let cmd = state.handle_bulk_select_key(key_shift('H'));
+        assert_eq!(cmd, Command::None);
+    }
+
+    #[test]
+    fn bulk_archive_goes_through_confirm() {
+        let mut state = make_state();
+        state.enter_bulk_select();
+        state.bulk_selected.insert("a".into());
+        state.bulk_selected.insert("b".into());
+        let cmd = state.handle_bulk_select_key(key(KeyCode::Char('a')));
+        assert_eq!(cmd, Command::None);
+        assert_eq!(state.mode, ViewMode::Confirm);
+    }
+}

--- a/src/app_state/mod.rs
+++ b/src/app_state/mod.rs
@@ -21,6 +21,7 @@ use crate::model::state::{
 use crate::model::state::{SIDEBAR_ASSIGNEES, SIDEBAR_LABELS};
 
 mod board;
+mod bulk;
 mod detail;
 mod filter;
 mod modal;
@@ -65,6 +66,7 @@ fn scene_from_mode_tag(mode: &ViewMode) -> Scene {
             debug_assert!(false, "GroupBySelect scene must be entered via enter_group_by_select()");
             Scene::Board
         }
+        ViewMode::BulkSelect => Scene::BulkSelect,
     }
 }
 
@@ -184,6 +186,9 @@ pub struct AppState {
 
     /// 新しい release が GitHub 上に公開されていれば、その tag (v プレフィックス除去済み)。
     pub update_available: Option<String>,
+
+    /// Bulk 選択モード中に選ばれている item_id の集合。
+    pub bulk_selected: std::collections::HashSet<String>,
 }
 
 impl AppState {
@@ -232,6 +237,7 @@ impl AppState {
             scene: Scene::ProjectSelect,
             previous_scene: None,
             update_available: None,
+            bulk_selected: std::collections::HashSet::new(),
         }
     }
 
@@ -987,6 +993,10 @@ impl AppState {
                 self.mode = ViewMode::CreateCard;
                 Some(Command::None)
             }
+            Action::BulkSelectStart => {
+                self.enter_bulk_select();
+                Some(Command::None)
+            }
             _ => None,
         }
     }
@@ -1044,6 +1054,7 @@ impl AppState {
             ViewMode::CommentList => self.handle_comment_list_key(key),
             ViewMode::GroupBySelect => self.handle_group_by_select_key(key),
             ViewMode::ReactionPicker => self.handle_reaction_picker_key(key),
+            ViewMode::BulkSelect => self.handle_bulk_select_key(key),
         }
     }
 
@@ -1617,6 +1628,7 @@ mod tests {
         assert_eq!(confirm.title, "My Card");
         match &confirm.action {
             ConfirmAction::ArchiveCard { item_id } => assert_eq!(item_id, "1"),
+            ConfirmAction::ArchiveMultipleCards { .. } => panic!("unexpected action"),
         }
     }
 

--- a/src/app_state/modal.rs
+++ b/src/app_state/modal.rs
@@ -13,10 +13,14 @@ impl AppState {
                     let return_to = state.return_to;
                     let cmd = match state.action {
                         ConfirmAction::ArchiveCard { item_id } => self.archive_card(&item_id),
+                        ConfirmAction::ArchiveMultipleCards { item_ids } => {
+                            self.archive_multiple_cards(&item_ids)
+                        }
                     };
                     // カードが消える破壊的操作は Detail には留まれない → Board に戻る
                     self.mode = match &cmd {
                         Command::ArchiveCard { .. } => ViewMode::Board,
+                        Command::Batch(_) => ViewMode::Board,
                         _ => return_to,
                     };
                     cmd

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -169,6 +169,7 @@ pub enum KeymapMode {
     FilterStructural,
     CreateCardGlobal,
     EditCardGlobal,
+    BulkSelect,
 }
 
 pub struct Keymap {
@@ -218,7 +219,8 @@ impl Keymap {
         board.insert(KeyBind::char('/'), Action::StartFilter);
         board.insert(KeyBind::ctrl('u'), Action::ClearFilter);
         board.insert(KeyBind::char('a'), Action::ArchiveCard);
-        board.insert(KeyBind::char('v'), Action::ShowArchivedList);
+        board.insert(KeyBind::char('A'), Action::ShowArchivedList);
+        board.insert(KeyBind::char('v'), Action::BulkSelectStart);
         board.insert(KeyBind::char('n'), Action::NewCard);
         board.insert(KeyBind::char(' '), Action::GrabCard);
         board.insert(KeyBind::ctrl('g'), Action::ChangeGrouping);
@@ -242,7 +244,8 @@ impl Keymap {
         table.insert(KeyBind::char('/'), Action::StartFilter);
         table.insert(KeyBind::ctrl('u'), Action::ClearFilter);
         table.insert(KeyBind::char('a'), Action::ArchiveCard);
-        table.insert(KeyBind::char('v'), Action::ShowArchivedList);
+        table.insert(KeyBind::char('A'), Action::ShowArchivedList);
+        table.insert(KeyBind::char('v'), Action::BulkSelectStart);
         table.insert(KeyBind::char('n'), Action::NewCard);
         table.insert(KeyBind::char(' '), Action::GrabCard);
         table.insert(KeyBind::ctrl('g'), Action::ChangeGrouping);
@@ -266,7 +269,7 @@ impl Keymap {
         roadmap.insert(KeyBind::char('/'), Action::StartFilter);
         roadmap.insert(KeyBind::ctrl('u'), Action::ClearFilter);
         roadmap.insert(KeyBind::char('a'), Action::ArchiveCard);
-        roadmap.insert(KeyBind::char('v'), Action::ShowArchivedList);
+        roadmap.insert(KeyBind::char('A'), Action::ShowArchivedList);
         roadmap.insert(KeyBind::char('n'), Action::NewCard);
         roadmap.insert(KeyBind::ctrl('g'), Action::ChangeGrouping);
         roadmap.insert(KeyBind::char('t'), Action::ToggleLayout);
@@ -459,6 +462,26 @@ impl Keymap {
         edit_card_body.insert(KeyBind::key(KeyCode::Enter), Action::OpenEditor);
         keymap.modes.insert(KeymapMode::EditCardBody, edit_card_body);
 
+        // BulkSelect mode
+        let mut bulk_select = HashMap::new();
+        bulk_select.insert(KeyBind::char('j'), Action::MoveDown);
+        bulk_select.insert(KeyBind::key(KeyCode::Down), Action::MoveDown);
+        bulk_select.insert(KeyBind::char('k'), Action::MoveUp);
+        bulk_select.insert(KeyBind::key(KeyCode::Up), Action::MoveUp);
+        bulk_select.insert(KeyBind::char('h'), Action::MoveLeft);
+        bulk_select.insert(KeyBind::key(KeyCode::Left), Action::MoveLeft);
+        bulk_select.insert(KeyBind::char('l'), Action::MoveRight);
+        bulk_select.insert(KeyBind::key(KeyCode::Right), Action::MoveRight);
+        bulk_select.insert(KeyBind::char(' '), Action::BulkSelectToggle);
+        bulk_select.insert(KeyBind::char('*'), Action::BulkSelectAll);
+        bulk_select.insert(KeyBind::char('a'), Action::BulkArchive);
+        bulk_select.insert(KeyBind::char('H'), Action::BulkMoveLeft);
+        bulk_select.insert(KeyBind::char('L'), Action::BulkMoveRight);
+        bulk_select.insert(KeyBind::char('v'), Action::BulkSelectClear);
+        bulk_select.insert(KeyBind::char('q'), Action::BulkSelectClear);
+        bulk_select.insert(KeyBind::key(KeyCode::Esc), Action::BulkSelectClear);
+        keymap.modes.insert(KeymapMode::BulkSelect, bulk_select);
+
         keymap
     }
 
@@ -489,6 +512,7 @@ impl Keymap {
             ("filter", KeymapMode::FilterStructural),
             ("create_card", KeymapMode::CreateCardGlobal),
             ("edit_card", KeymapMode::EditCardGlobal),
+            ("bulk_select", KeymapMode::BulkSelect),
         ];
 
         for (config_key, mode) in mode_configs {
@@ -625,6 +649,13 @@ fn parse_action_name(name: &str) -> Option<Action> {
         "toggle_item" => Some(Action::ToggleItem),
         "open_reaction_picker" => Some(Action::OpenReactionPicker),
         "toggle_reaction" => Some(Action::ToggleReaction),
+        "bulk_select_start" => Some(Action::BulkSelectStart),
+        "bulk_select_toggle" => Some(Action::BulkSelectToggle),
+        "bulk_select_all" => Some(Action::BulkSelectAll),
+        "bulk_select_clear" => Some(Action::BulkSelectClear),
+        "bulk_archive" => Some(Action::BulkArchive),
+        "bulk_move_left" => Some(Action::BulkMoveLeft),
+        "bulk_move_right" => Some(Action::BulkMoveRight),
         _ => None,
     }
 }
@@ -674,6 +705,13 @@ pub fn action_name(action: Action) -> &'static str {
         Action::ToggleItem => "toggle_item",
         Action::OpenReactionPicker => "open_reaction_picker",
         Action::ToggleReaction => "toggle_reaction",
+        Action::BulkSelectStart => "bulk_select_start",
+        Action::BulkSelectToggle => "bulk_select_toggle",
+        Action::BulkSelectAll => "bulk_select_all",
+        Action::BulkSelectClear => "bulk_select_clear",
+        Action::BulkArchive => "bulk_archive",
+        Action::BulkMoveLeft => "bulk_move_left",
+        Action::BulkMoveRight => "bulk_move_right",
     }
 }
 
@@ -809,6 +847,10 @@ mod tests {
         );
         assert_eq!(
             keymap.resolve(KeymapMode::Board, &make_key_event(KeyCode::Char('v'), KeyModifiers::NONE)),
+            Some(Action::BulkSelectStart)
+        );
+        assert_eq!(
+            keymap.resolve(KeymapMode::Board, &make_key_event(KeyCode::Char('A'), KeyModifiers::NONE)),
             Some(Action::ShowArchivedList)
         );
         assert_eq!(
@@ -877,6 +919,35 @@ mod tests {
         assert_eq!(
             keymap.resolve(KeymapMode::CardGrab, &make_key_event(KeyCode::Esc, KeyModifiers::NONE)),
             Some(Action::CancelGrab)
+        );
+    }
+
+    #[test]
+    fn test_resolve_bulk_select() {
+        let keymap = Keymap::default_keymap();
+        assert_eq!(
+            keymap.resolve(KeymapMode::BulkSelect, &make_key_event(KeyCode::Char(' '), KeyModifiers::NONE)),
+            Some(Action::BulkSelectToggle)
+        );
+        assert_eq!(
+            keymap.resolve(KeymapMode::BulkSelect, &make_key_event(KeyCode::Char('a'), KeyModifiers::NONE)),
+            Some(Action::BulkArchive)
+        );
+        assert_eq!(
+            keymap.resolve(KeymapMode::BulkSelect, &make_key_event(KeyCode::Char('H'), KeyModifiers::NONE)),
+            Some(Action::BulkMoveLeft)
+        );
+        assert_eq!(
+            keymap.resolve(KeymapMode::BulkSelect, &make_key_event(KeyCode::Char('L'), KeyModifiers::NONE)),
+            Some(Action::BulkMoveRight)
+        );
+        assert_eq!(
+            keymap.resolve(KeymapMode::BulkSelect, &make_key_event(KeyCode::Char('v'), KeyModifiers::NONE)),
+            Some(Action::BulkSelectClear)
+        );
+        assert_eq!(
+            keymap.resolve(KeymapMode::BulkSelect, &make_key_event(KeyCode::Esc, KeyModifiers::NONE)),
+            Some(Action::BulkSelectClear)
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -312,6 +312,10 @@ fn render(frame: &mut Frame, app: &App) {
             }
             ui::reaction_picker::render(frame, area, picker, app);
         }
+        Scene::BulkSelect => {
+            render_board_with_tabs(frame, main_area, app);
+            ui::statusline::render(frame, area, app);
+        }
     }
 
     // Loading/error overlay (Refreshing は statusline 側で控えめに表示)

--- a/src/model/state.rs
+++ b/src/model/state.rs
@@ -20,6 +20,7 @@ pub enum ViewMode {
     CommentList,
     GroupBySelect,
     ReactionPicker,
+    BulkSelect,
 }
 
 /// 現在表示中の「シーン」。Phase B リファクタで段階的にモード固有の state を
@@ -48,6 +49,7 @@ pub enum Scene {
     CommentList(CommentListState),
     GroupBySelect(GroupBySelectState),
     ReactionPicker(ReactionPickerState),
+    BulkSelect,
 }
 
 /// Board の表示レイアウト。Kanban (Board) / Table / Roadmap の 3 種類をサポート。
@@ -147,6 +149,7 @@ pub struct ConfirmState {
 #[derive(Clone, Debug)]
 pub enum ConfirmAction {
     ArchiveCard { item_id: String },
+    ArchiveMultipleCards { item_ids: Vec<String> },
 }
 
 #[derive(Clone, Debug)]

--- a/src/ui/board.rs
+++ b/src/ui/board.rs
@@ -161,12 +161,16 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
 
             let selected = is_selected_col && display_idx == app.state.selected_card;
             let grabbing = app.state.mode == ViewMode::CardGrab && selected;
+            let card = &column.cards[card_idx];
+            let bulk_selected = app.state.mode == ViewMode::BulkSelect
+                && app.state.bulk_selected.contains(&card.item_id);
 
             frame.render_widget(
                 CardWidget {
-                    card: &column.cards[card_idx],
+                    card,
                     selected,
                     grabbing,
+                    bulk_selected,
                 },
                 card_area,
             );

--- a/src/ui/card.rs
+++ b/src/ui/card.rs
@@ -19,14 +19,31 @@ pub struct CardWidget<'a> {
     pub card: &'a Card,
     pub selected: bool,
     pub grabbing: bool,
+    /// Bulk 選択モード中にこのカードが選択済みか。先頭 indicator とボーダー強調に使う。
+    pub bulk_selected: bool,
 }
 
 impl Widget for CardWidget<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
+        // 「色」でカードの選択状態、「ボーダー種別」でカーソル位置を表す。
+        // bulk_selected + selected が重なった場合は太ボーダー + accent 色で
+        // 両方が立っていることが一目で分かるようにする。
         let (border_style, border_type) = if self.grabbing {
             (
                 Style::default().fg(theme().yellow),
                 BorderType::Thick,
+            )
+        } else if self.bulk_selected && self.selected {
+            (
+                Style::default()
+                    .fg(theme().accent)
+                    .add_modifier(Modifier::BOLD),
+                BorderType::Thick,
+            )
+        } else if self.bulk_selected {
+            (
+                Style::default().fg(theme().accent),
+                BorderType::Rounded,
             )
         } else if self.selected {
             (
@@ -61,7 +78,16 @@ impl Widget for CardWidget<'_> {
             .map(|n| format!("#{n} "))
             .unwrap_or_default();
 
-        let mut title_spans = vec![type_indicator];
+        let mut title_spans = Vec::new();
+        if self.bulk_selected {
+            title_spans.push(Span::styled(
+                "✓ ",
+                Style::default()
+                    .fg(theme().accent)
+                    .add_modifier(Modifier::BOLD),
+            ));
+        }
+        title_spans.push(type_indicator);
         if matches!(self.card.card_type, CardType::PullRequest { .. })
             && let Some(status) = &self.card.pr_status
         {
@@ -298,7 +324,7 @@ mod tests {
         terminal
             .draw(|f| {
                 f.render_widget(
-                    CardWidget { card, selected, grabbing },
+                    CardWidget { card, selected, grabbing, bulk_selected: false },
                     Rect::new(0, 0, width, CARD_HEIGHT),
                 );
             })

--- a/src/ui/confirm.rs
+++ b/src/ui/confirm.rs
@@ -15,7 +15,9 @@ pub fn render(frame: &mut Frame, area: Rect, state: &ConfirmState) {
     frame.render_widget(Clear, popup);
 
     let accent = match state.action {
-        ConfirmAction::ArchiveCard { .. } => theme().yellow,
+        ConfirmAction::ArchiveCard { .. } | ConfirmAction::ArchiveMultipleCards { .. } => {
+            theme().yellow
+        }
     };
 
     let block = Block::default()
@@ -33,8 +35,11 @@ pub fn render(frame: &mut Frame, area: Rect, state: &ConfirmState) {
         .fg(theme().yellow)
         .add_modifier(Modifier::BOLD);
 
-    let message = match state.action {
+    let message = match &state.action {
         ConfirmAction::ArchiveCard { .. } => format!("  Archive \"{}\"?", state.title),
+        ConfirmAction::ArchiveMultipleCards { item_ids } => {
+            format!("  Archive {} selected cards?", item_ids.len())
+        }
     };
 
     let lines = vec![

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -82,6 +82,7 @@ pub fn render(frame: &mut Frame, area: Rect, keymap: &Keymap) {
         HelpEntry { action: Action::NewCard, description: "New card (draft/issue)" },
         HelpEntry { action: Action::ArchiveCard, description: "Archive card" },
         HelpEntry { action: Action::ShowArchivedList, description: "Open archive page in browser" },
+        HelpEntry { action: Action::BulkSelectStart, description: "Bulk select mode (Space:toggle *:all a:archive H/L:move)" },
         HelpEntry { action: Action::OpenDetail, description: "View card detail" },
         HelpEntry { action: Action::SwitchProject, description: "Switch project" },
         HelpEntry { action: Action::ChangeGrouping, description: "Change grouping field" },

--- a/src/ui/statusline.rs
+++ b/src/ui/statusline.rs
@@ -126,6 +126,27 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
             grab_hints,
             Style::default().fg(theme().text_muted),
         ));
+    } else if app.state.mode == ViewMode::BulkSelect {
+        let count = app.state.bulk_selected.len();
+        let hints = format!(
+            " hjkl:move  {}:toggle  {}:all  {}:archive  H/L:move col  {}:exit  ({} selected) ",
+            build_hint_pair(app, KeymapMode::BulkSelect, &[(Action::BulkSelectToggle, "toggle")]),
+            build_hint_pair(app, KeymapMode::BulkSelect, &[(Action::BulkSelectAll, "all")]),
+            build_hint_pair(app, KeymapMode::BulkSelect, &[(Action::BulkArchive, "archive")]),
+            build_hint_pair(app, KeymapMode::BulkSelect, &[(Action::BulkSelectClear, "exit")]),
+            count,
+        );
+        spans.push(Span::styled(
+            " BULK ",
+            Style::default()
+                .fg(theme().text_inverted)
+                .bg(theme().accent)
+                .add_modifier(Modifier::BOLD),
+        ));
+        spans.push(Span::styled(
+            hints,
+            Style::default().fg(theme().text_muted),
+        ));
     } else {
         let mode = match app.state.current_layout {
             LayoutMode::Board => KeymapMode::Board,

--- a/src/ui/table.rs
+++ b/src/ui/table.rs
@@ -205,6 +205,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
     let cols = build_columns(board);
     let constraints: Vec<Constraint> = cols.iter().map(col_constraint).collect();
 
+    let is_bulk = app.state.mode == ViewMode::BulkSelect;
     let rows: Vec<Row> = app
         .state
         .table_rows()
@@ -212,12 +213,20 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
         .map(|&(col_idx, card_idx)| {
             let column = &board.columns[col_idx];
             let card = &column.cards[card_idx];
-            Row::new(
+            let mut row = Row::new(
                 cols.iter()
                     .map(|c| cell_for(card, c, &column.name))
                     .collect::<Vec<_>>(),
             )
-            .height(1)
+            .height(1);
+            if is_bulk && app.state.bulk_selected.contains(&card.item_id) {
+                row = row.style(
+                    Style::default()
+                        .fg(theme().accent)
+                        .add_modifier(Modifier::BOLD),
+                );
+            }
+            row
         })
         .collect();
 


### PR DESCRIPTION
## Summary
複数カードをまとめて archive / カラム移動できる bulk 選択モードを追加 (closes #54)

### キー
- \`v\`: Bulk 選択モードに入る (Board / Table layout 対応)
- \`Space\`: カーソル位置のカードをトグル
- \`*\`: 現在カラム (Board) / 全行 (Table) の全カードを選択
- \`a\`: 選択済みを一括 archive (Confirm 経由)
- \`H\` / \`L\`: 選択済みを左 / 右のカラムに一括移動 (Board, SingleSelect grouping 限定)
- \`Esc\` / \`q\` / \`v\`: Bulk モードを解除

既存の \`v\` (archive ページをブラウザで開く) は \`A\` に退避しました。

### UI
- 選択済みカード: accent 色 + 先頭に \`✓\`
- カーソル + 選択済み: 太ボーダー + BOLD で両方の状態が一目で分かる
- ステータスバーに \`BULK\` バッジと選択件数を表示

### 実装
- \`AppState.bulk_selected: HashSet<String>\` に item_id を保持
- \`app_state/bulk.rs\` に選択モードのキー処理と一括 archive/move ロジックを集約
- Batch Command (既存) を使って単体 mutation を並列発行するので GraphQL 側は変更なし

## Test plan
- [x] \`cargo test\` (403 passed)
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [ ] Board layout で v → Space → a → Confirm → 一括 archive
- [ ] Board layout で v → Space → L で一括右カラム移動
- [ ] Table layout で v → j/k → Space → a で一括 archive
- [ ] フィルタ適用中の Space トグルが正しいカードを参照する

🤖 Generated with [Claude Code](https://claude.com/claude-code)