### PR TITLE
feat(detail): y キーで URL をクリップボードにコピー (OSC 52)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,7 @@ curl -L -o schema.graphql https://raw.githubusercontent.com/octokit/graphql-sche
 - c: 新規コメント投稿 ($EDITOR 経由、Issue/PR のみ)
 - C: コメント一覧 (ViewMode::CommentList) を開く
 - Enter/o: ブラウザで開く、Esc/q: ボードに戻る
+- y: 選択中カードの URL をクリップボードにコピー (OSC 52 経由、依存追加なし)。`ViewMode::CommentList` でも選択中のコメント URL をコピー可能。成功時は `AppState.toast` にメッセージをセットし、ステータスライン右端に一時表示 (次のキー入力で自動クリア)
 - Markdown レンダリング: tui-markdown でヘッダー・太字・コード等を装飾表示
 - テーブル: pulldown-cmark でパースし罫線文字で自前レンダリング。ビューポートに収まらないテーブルのみ h/l で横スクロール可能
 - 非テーブルテキストは表示幅に合わせて自動折り返し (wrap_line)

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -33,6 +33,7 @@ help:
     detail_table_scroll: "Table scroll"
     detail_switch_sidebar: "Switch to sidebar"
     open_in_browser: "Open in browser"
+    copy_url: "Copy URL to clipboard (OSC 52)"
     edit_card: "Edit card"
     new_comment: "New comment"
     open_comment_list: "Comment list"

--- a/locales/ja.yml
+++ b/locales/ja.yml
@@ -33,6 +33,7 @@ help:
     detail_table_scroll: "テーブル横スクロール"
     detail_switch_sidebar: "サイドバーへ"
     open_in_browser: "ブラウザで開く"
+    copy_url: "URL をクリップボードにコピー (OSC 52)"
     edit_card: "カード編集"
     new_comment: "新規コメント"
     open_comment_list: "コメント一覧"

--- a/src/action.rs
+++ b/src/action.rs
@@ -34,6 +34,7 @@ pub enum Action {
     EditCard,
     NewComment,
     OpenCommentList,
+    CopyUrl,
 
     // Detail sidebar / confirm / grab / forms
     Select,

--- a/src/app.rs
+++ b/src/app.rs
@@ -541,6 +541,10 @@ impl App {
             Command::OpenUrl(url) => {
                 let _ = open::that(&url);
             }
+            Command::CopyToClipboard(text) => {
+                let mut stdout = std::io::stdout();
+                let _ = crate::clipboard::write_osc52(&mut stdout, &text);
+            }
             Command::UpdateCustomField {
                 project_id,
                 item_id,

--- a/src/app_state/detail.rs
+++ b/src/app_state/detail.rs
@@ -141,7 +141,21 @@ impl AppState {
             Action::NewComment => self.start_new_comment(),
             Action::OpenCommentList => self.open_comment_list(),
             Action::OpenReactionPicker => self.open_reaction_picker_for_card(),
+            Action::CopyUrl => self.copy_current_card_url(),
             _ => Command::None,
+        }
+    }
+
+    pub(super) fn copy_current_card_url(&mut self) -> Command {
+        let url = self
+            .current_detail_card()
+            .and_then(|c| c.url.clone());
+        match url {
+            Some(u) => {
+                self.toast = Some(format!("Copied URL: {u}"));
+                Command::CopyToClipboard(u)
+            }
+            None => Command::None,
         }
     }
 
@@ -649,8 +663,27 @@ impl AppState {
                 }
             }
             Action::OpenReactionPicker => self.open_reaction_picker_for_comment(),
+            Action::CopyUrl => self.copy_current_comment_url(),
             _ => Command::None,
         }
+    }
+
+    pub(super) fn copy_current_comment_url(&mut self) -> Command {
+        let cls = match self.comment_list_state() {
+            Some(s) => s,
+            None => return Command::None,
+        };
+        let cursor = cls.cursor;
+        let card = match self.selected_card_ref() {
+            Some(c) => c,
+            None => return Command::None,
+        };
+        let url = match card.comments.get(cursor).and_then(|c| c.url.clone()) {
+            Some(u) => u,
+            None => return Command::None,
+        };
+        self.toast = Some(format!("Copied URL: {url}"));
+        Command::CopyToClipboard(url)
     }
 
     pub(super) fn find_card_by_content_id_mut(&mut self, content_id: &str) -> Option<&mut Card> {

--- a/src/app_state/mod.rs
+++ b/src/app_state/mod.rs
@@ -189,6 +189,10 @@ pub struct AppState {
 
     /// Bulk 選択モード中に選ばれている item_id の集合。
     pub bulk_selected: std::collections::HashSet<String>,
+
+    /// ステータスラインの右側に一時表示するメッセージ (例: "Copied URL")。
+    /// 次のキー入力で自動クリアされる。
+    pub toast: Option<String>,
 }
 
 impl AppState {
@@ -238,6 +242,7 @@ impl AppState {
             previous_scene: None,
             update_available: None,
             bulk_selected: std::collections::HashSet::new(),
+            toast: None,
         }
     }
 
@@ -1018,6 +1023,9 @@ impl AppState {
         if key.kind != KeyEventKind::Press {
             return Command::None;
         }
+
+        // トーストは次のキー入力で消す (CopyUrl ハンドラが必要なら再設定する流れ)。
+        self.toast = None;
 
         // Clear error on any key press
         if matches!(self.loading, LoadingState::Error(_)) {
@@ -4050,6 +4058,7 @@ mod tests {
             body: body.into(),
             created_at: "2024-01-01T00:00:00Z".into(),
             reactions: vec![],
+            url: Some(format!("https://github.com/owner/repo/issues/1#issuecomment-{id}")),
         }
     }
 
@@ -4081,6 +4090,80 @@ mod tests {
             sub_issues_summary: None,
             sub_issues: vec![],
         }
+    }
+
+    // ========== URL コピー (OSC 52) テスト ==========
+
+    #[test]
+    fn detail_y_copies_card_url_and_sets_toast() {
+        let card = make_issue_card_with_comments("1", "Card A", vec![]);
+        let board = make_board(vec![("Todo", "opt_1", vec![card])]);
+        let mut state = make_state_with_board(board);
+
+        let _ = state.handle_event(AppEvent::Key(key(KeyCode::Enter)));
+        assert_eq!(state.mode, ViewMode::Detail);
+
+        let cmd = state.handle_event(AppEvent::Key(key(KeyCode::Char('y'))));
+        assert_eq!(
+            cmd,
+            Command::CopyToClipboard("https://github.com/owner/repo/issues/1".into())
+        );
+        assert!(state.toast.as_deref().unwrap_or("").contains("Copied URL"));
+    }
+
+    #[test]
+    fn detail_y_without_url_returns_none() {
+        let mut card = make_issue_card_with_comments("1", "Card A", vec![]);
+        card.url = None;
+        let board = make_board(vec![("Todo", "opt_1", vec![card])]);
+        let mut state = make_state_with_board(board);
+
+        let _ = state.handle_event(AppEvent::Key(key(KeyCode::Enter)));
+        let cmd = state.handle_event(AppEvent::Key(key(KeyCode::Char('y'))));
+        assert_eq!(cmd, Command::None);
+        assert!(state.toast.is_none());
+    }
+
+    #[test]
+    fn comment_list_y_copies_selected_comment_url() {
+        let comments = vec![
+            make_comment("c1", "me", "first"),
+            make_comment("c2", "other", "second"),
+        ];
+        let card = make_issue_card_with_comments("1", "Card A", comments);
+        let board = make_board(vec![("Todo", "opt_1", vec![card])]);
+        let mut state = make_state_with_board(board);
+
+        // Detail → CommentList
+        let _ = state.handle_event(AppEvent::Key(key(KeyCode::Enter)));
+        let _ = state.handle_event(AppEvent::Key(key(KeyCode::Char('C'))));
+        assert_eq!(state.mode, ViewMode::CommentList);
+
+        // 2 件目に移動してコピー
+        let _ = state.handle_event(AppEvent::Key(key(KeyCode::Char('j'))));
+        let cmd = state.handle_event(AppEvent::Key(key(KeyCode::Char('y'))));
+        assert_eq!(
+            cmd,
+            Command::CopyToClipboard(
+                "https://github.com/owner/repo/issues/1#issuecomment-c2".into()
+            )
+        );
+        assert!(state.toast.as_deref().unwrap_or("").contains("Copied URL"));
+    }
+
+    #[test]
+    fn toast_clears_on_next_key() {
+        let card = make_issue_card_with_comments("1", "Card A", vec![]);
+        let board = make_board(vec![("Todo", "opt_1", vec![card])]);
+        let mut state = make_state_with_board(board);
+
+        let _ = state.handle_event(AppEvent::Key(key(KeyCode::Enter)));
+        let _ = state.handle_event(AppEvent::Key(key(KeyCode::Char('y'))));
+        assert!(state.toast.is_some());
+
+        // 次のキー入力で消える
+        let _ = state.handle_event(AppEvent::Key(key(KeyCode::Char('j'))));
+        assert!(state.toast.is_none());
     }
 
     // ========== コメント投稿テスト ==========
@@ -4324,6 +4407,7 @@ mod tests {
             body: "updated body".into(),
             created_at: String::new(),
             reactions: vec![],
+            url: None,
         };
         let _ = state.handle_event(AppEvent::CommentUpdated(Ok(updated)));
 
@@ -6417,6 +6501,7 @@ mod tests {
                 body: "A comment".into(),
                 created_at: "2024-01-01T00:00:00Z".into(),
                 reactions: vec![],
+                url: None,
             }],
             reactions: vec![],
             linked_prs: vec![],
@@ -6450,6 +6535,7 @@ mod tests {
                 body: format!("comment {i}"),
                 created_at: "2024-01-01T00:00:00Z".into(),
                 reactions: vec![],
+                url: None,
             })
             .collect();
 

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -1,0 +1,118 @@
+use std::io::Write;
+
+/// OSC 52 escape sequence for writing `data` to the terminal's clipboard.
+///
+/// Format: `ESC ] 52 ; c ; <base64(data)> ST` where ST is `\x1b\\` (canonical)
+/// or `\x07` (BEL, widely accepted).
+pub fn osc52_sequence(data: &str) -> String {
+    let encoded = base64_encode(data.as_bytes());
+    format!("\x1b]52;c;{encoded}\x1b\\")
+}
+
+/// Wrap an escape sequence for tmux DCS passthrough.
+///
+/// tmux は OSC 52 を既定で外側へ透過させないため、`ESC P tmux ; <escaped> ESC \`
+/// の DCS で包む必要がある。内側の ESC は二重化する。
+/// 受信側 tmux の `allow-passthrough on` が必要 (tmux >= 3.3 / 3.4+ で既定 on)。
+pub fn wrap_for_tmux(seq: &str) -> String {
+    let escaped = seq.replace('\x1b', "\x1b\x1b");
+    format!("\x1bPtmux;{escaped}\x1b\\")
+}
+
+/// Build the OSC 52 payload. tmux 配下 (`$TMUX` が定義されている) では DCS でラップし、
+/// tmux のフィルタを通り抜けて外側のターミナルに届くようにする。
+pub fn clipboard_payload(data: &str, inside_tmux: bool) -> String {
+    let raw = osc52_sequence(data);
+    if inside_tmux { wrap_for_tmux(&raw) } else { raw }
+}
+
+/// Write the OSC 52 clipboard sequence to the given writer (typically stdout).
+pub fn write_osc52<W: Write>(writer: &mut W, data: &str) -> std::io::Result<()> {
+    let inside_tmux = std::env::var_os("TMUX").is_some();
+    writer.write_all(clipboard_payload(data, inside_tmux).as_bytes())?;
+    writer.flush()
+}
+
+fn base64_encode(input: &[u8]) -> String {
+    const CHARSET: &[u8; 64] =
+        b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity(input.len().div_ceil(3) * 4);
+    let mut i = 0;
+    while i + 3 <= input.len() {
+        let n = ((input[i] as u32) << 16) | ((input[i + 1] as u32) << 8) | (input[i + 2] as u32);
+        out.push(CHARSET[((n >> 18) & 0x3f) as usize] as char);
+        out.push(CHARSET[((n >> 12) & 0x3f) as usize] as char);
+        out.push(CHARSET[((n >> 6) & 0x3f) as usize] as char);
+        out.push(CHARSET[(n & 0x3f) as usize] as char);
+        i += 3;
+    }
+    let rem = input.len() - i;
+    if rem == 1 {
+        let n = (input[i] as u32) << 16;
+        out.push(CHARSET[((n >> 18) & 0x3f) as usize] as char);
+        out.push(CHARSET[((n >> 12) & 0x3f) as usize] as char);
+        out.push('=');
+        out.push('=');
+    } else if rem == 2 {
+        let n = ((input[i] as u32) << 16) | ((input[i + 1] as u32) << 8);
+        out.push(CHARSET[((n >> 18) & 0x3f) as usize] as char);
+        out.push(CHARSET[((n >> 12) & 0x3f) as usize] as char);
+        out.push(CHARSET[((n >> 6) & 0x3f) as usize] as char);
+        out.push('=');
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn base64_known_vectors() {
+        assert_eq!(base64_encode(b""), "");
+        assert_eq!(base64_encode(b"f"), "Zg==");
+        assert_eq!(base64_encode(b"fo"), "Zm8=");
+        assert_eq!(base64_encode(b"foo"), "Zm9v");
+        assert_eq!(base64_encode(b"foob"), "Zm9vYg==");
+        assert_eq!(base64_encode(b"fooba"), "Zm9vYmE=");
+        assert_eq!(base64_encode(b"foobar"), "Zm9vYmFy");
+    }
+
+    #[test]
+    fn osc52_sequence_wraps_base64() {
+        let s = osc52_sequence("hi");
+        assert_eq!(s, "\x1b]52;c;aGk=\x1b\\");
+    }
+
+    #[test]
+    fn osc52_sequence_handles_url() {
+        let s = osc52_sequence("https://example.com/issues/1");
+        assert!(s.starts_with("\x1b]52;c;"));
+        assert!(s.ends_with("\x1b\\"));
+    }
+
+    #[test]
+    fn wrap_for_tmux_doubles_escapes_and_wraps_in_dcs() {
+        let inner = osc52_sequence("hi"); // \x1b]52;c;aGk=\x1b\\
+        let wrapped = wrap_for_tmux(&inner);
+        assert_eq!(
+            wrapped,
+            "\x1bPtmux;\x1b\x1b]52;c;aGk=\x1b\x1b\\\x1b\\"
+        );
+    }
+
+    #[test]
+    fn clipboard_payload_outside_tmux_is_raw() {
+        let p = clipboard_payload("hi", false);
+        assert_eq!(p, osc52_sequence("hi"));
+    }
+
+    #[test]
+    fn clipboard_payload_inside_tmux_wraps() {
+        let p = clipboard_payload("hi", true);
+        assert!(p.starts_with("\x1bPtmux;"));
+        assert!(p.ends_with("\x1b\\"));
+        // 内側の ESC が二重化されていること
+        assert!(p.contains("\x1b\x1b]52;c;aGk="));
+    }
+}

--- a/src/command.rs
+++ b/src/command.rs
@@ -115,6 +115,8 @@ pub enum Command {
         content: crate::model::project::ReactionContent,
     },
     OpenUrl(String),
+    /// OSC 52 でターミナルのクリップボードに文字列を書き込む
+    CopyToClipboard(String),
     UpdateCustomField {
         project_id: String,
         item_id: String,

--- a/src/github/client/mutations.rs
+++ b/src/github/client/mutations.rs
@@ -282,6 +282,7 @@ impl GitHubClient {
             body: node.body,
             created_at: node.created_at,
             reactions,
+            url: Some(node.url),
         })
     }
 
@@ -306,6 +307,7 @@ impl GitHubClient {
             body: node.body,
             created_at: String::new(), // Will be filled by caller
             reactions: Vec::new(),
+            url: Some(node.url),
         })
     }
 

--- a/src/github/client/queries.rs
+++ b/src/github/client/queries.rs
@@ -471,6 +471,7 @@ impl GitHubClient {
                                 body: c.body,
                                 created_at: c.created_at,
                                 reactions,
+                                url: Some(c.url),
                             });
                         }
                     }
@@ -489,6 +490,7 @@ impl GitHubClient {
                                 body: c.body,
                                 created_at: c.created_at,
                                 reactions,
+                                url: Some(c.url),
                             });
                         }
                     }
@@ -559,6 +561,7 @@ impl GitHubClient {
                             c.reaction_groups.as_ref(),
                             |g| (&g.content, g.reactors.total_count, g.viewer_has_reacted),
                         ),
+                        url: Some(c.url.clone()),
                     })
                     .collect()
             })
@@ -664,6 +667,7 @@ impl GitHubClient {
                                     c.reaction_groups.as_ref(),
                                     |g| (&g.content, g.reactors.total_count, g.viewer_has_reacted),
                                 ),
+                                url: Some(c.url.clone()),
                             })
                             .collect()
                     })
@@ -716,6 +720,7 @@ impl GitHubClient {
                             c.reaction_groups.as_ref(),
                             |g| (&g.content, g.reactors.total_count, g.viewer_has_reacted),
                         ),
+                        url: Some(c.url.clone()),
                     })
                     .collect()
             })

--- a/src/github/graphql/add_comment.graphql
+++ b/src/github/graphql/add_comment.graphql
@@ -3,6 +3,7 @@ mutation AddComment($subjectId: ID!, $body: String!) {
     commentEdge {
       node {
         id
+        url
         author { __typename login }
         body
         createdAt

--- a/src/github/graphql/fetch_card_detail.graphql
+++ b/src/github/graphql/fetch_card_detail.graphql
@@ -12,6 +12,7 @@ query FetchCardDetail($id: ID!) {
       comments(first: 20) {
         nodes {
           id
+          url
           author { __typename login }
           body
           createdAt
@@ -42,6 +43,7 @@ query FetchCardDetail($id: ID!) {
       comments(first: 20) {
         nodes {
           id
+          url
           author { __typename login }
           body
           createdAt

--- a/src/github/graphql/fetch_comments.graphql
+++ b/src/github/graphql/fetch_comments.graphql
@@ -6,6 +6,7 @@ query FetchComments($id: ID!, $cursor: String) {
         pageInfo { hasNextPage endCursor }
         nodes {
           id
+          url
           author { __typename login }
           body
           createdAt
@@ -22,6 +23,7 @@ query FetchComments($id: ID!, $cursor: String) {
         pageInfo { hasNextPage endCursor }
         nodes {
           id
+          url
           author { __typename login }
           body
           createdAt

--- a/src/github/graphql/fetch_issue.graphql
+++ b/src/github/graphql/fetch_issue.graphql
@@ -19,6 +19,7 @@ query FetchIssue($id: ID!) {
       comments(first: 20) {
         nodes {
           id
+          url
           author { __typename login }
           body
           createdAt

--- a/src/github/graphql/update_issue_comment.graphql
+++ b/src/github/graphql/update_issue_comment.graphql
@@ -2,6 +2,7 @@ mutation UpdateIssueComment($id: ID!, $body: String!) {
   updateIssueComment(input: { id: $id, body: $body }) {
     issueComment {
       id
+      url
       body
     }
   }

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -375,6 +375,7 @@ impl Keymap {
         detail_content.insert(KeyBind::char('c'), Action::NewComment);
         detail_content.insert(KeyBind::char('C'), Action::OpenCommentList);
         detail_content.insert(KeyBind::char('r'), Action::OpenReactionPicker);
+        detail_content.insert(KeyBind::char('y'), Action::CopyUrl);
         keymap.modes.insert(KeymapMode::DetailContent, detail_content);
 
         // Detail sidebar
@@ -424,6 +425,7 @@ impl Keymap {
         comment_list.insert(KeyBind::char('e'), Action::EditComment);
         comment_list.insert(KeyBind::char('c'), Action::NewComment);
         comment_list.insert(KeyBind::char('r'), Action::OpenReactionPicker);
+        comment_list.insert(KeyBind::char('y'), Action::CopyUrl);
         keymap.modes.insert(KeymapMode::CommentList, comment_list);
 
         // GroupBySelect mode
@@ -635,6 +637,7 @@ fn parse_action_name(name: &str) -> Option<Action> {
         "edit_card" => Some(Action::EditCard),
         "new_comment" => Some(Action::NewComment),
         "open_comment_list" => Some(Action::OpenCommentList),
+        "copy_url" => Some(Action::CopyUrl),
         "select" => Some(Action::Select),
         "confirm_yes" => Some(Action::ConfirmYes),
         "confirm_no" => Some(Action::ConfirmNo),
@@ -691,6 +694,7 @@ pub fn action_name(action: Action) -> &'static str {
         Action::EditCard => "edit_card",
         Action::NewComment => "new_comment",
         Action::OpenCommentList => "open_comment_list",
+        Action::CopyUrl => "copy_url",
         Action::Select => "select",
         Action::ConfirmYes => "confirm_yes",
         Action::ConfirmNo => "confirm_no",

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod app;
 mod app_state;
 mod cache;
 mod cli;
+mod clipboard;
 mod color;
 mod command;
 mod config;

--- a/src/model/project.rs
+++ b/src/model/project.rs
@@ -316,6 +316,9 @@ pub struct Comment {
     pub body: String,
     pub created_at: String,
     pub reactions: Vec<ReactionSummary>,
+    /// Permalink (`https://github.com/.../#issuecomment-<id>`)。旧キャッシュ互換で省略可。
+    #[serde(default)]
+    pub url: Option<String>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -120,6 +120,7 @@ pub fn render(frame: &mut Frame, area: Rect, keymap: &Keymap) {
         entry(Action::MoveLeft, "help.entries.detail_table_scroll"),
         entry(Action::NextTab, "help.entries.detail_switch_sidebar"),
         entry(Action::OpenInBrowser, "help.entries.open_in_browser"),
+        entry(Action::CopyUrl, "help.entries.copy_url"),
         entry(Action::EditCard, "help.entries.edit_card"),
         entry(Action::NewComment, "help.entries.new_comment"),
         entry(Action::OpenCommentList, "help.entries.open_comment_list"),
@@ -138,6 +139,7 @@ pub fn render(frame: &mut Frame, area: Rect, keymap: &Keymap) {
         entry(Action::MoveUp, "help.entries.comment_prev"),
         entry(Action::EditComment, "help.entries.edit_own_comment"),
         entry(Action::NewComment, "help.entries.new_comment"),
+        entry(Action::CopyUrl, "help.entries.copy_url"),
         entry(Action::OpenReactionPicker, "help.entries.toggle_reaction_selected"),
         entry(Action::Back, "help.entries.back_to_detail"),
     ];

--- a/src/ui/statusline.rs
+++ b/src/ui/statusline.rs
@@ -187,8 +187,9 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
     frame.render_widget(line, status_area);
 
     // 右端に loading status (アニメーション付き) を重ねて描画
-    // loading が無いときに限り、update 通知を同じ位置に表示する
+    // loading が無いときに限り、toast → update 通知の順で同じ位置に表示する
     let right_line = build_loading_line(&app.state.loading)
+        .or_else(|| build_toast_line(app.state.toast.as_deref()))
         .or_else(|| build_update_line(app.state.update_available.as_deref()));
     if let Some(line) = right_line {
         let width = line.width() as u16;
@@ -215,6 +216,14 @@ pub(crate) fn loading_spinner_span(loading: &LoadingState) -> Option<Span<'stati
         }
         _ => None,
     }
+}
+
+fn build_toast_line(toast: Option<&str>) -> Option<Line<'static>> {
+    let msg = toast?;
+    let style = Style::default()
+        .fg(theme().green)
+        .add_modifier(Modifier::BOLD);
+    Some(Line::from(vec![Span::styled(format!("{msg} "), style)]))
 }
 
 fn build_update_line(update_available: Option<&str>) -> Option<Line<'static>> {


### PR DESCRIPTION
## Summary
- 詳細ビュー / コメント一覧で `y` を押すと URL が OSC 52 経由でクリップボードに入る
- tmux 配下では DCS passthrough で包み、外側ターミナルに透過 (ghostty / iTerm2 / kitty / WezTerm / Alacritty で動作確認用)
- コピー成功時はステータスライン右端に `Copied URL: ...` を緑で一時表示 (次のキー入力で自動クリア)

## Changes
- `src/clipboard.rs`: OSC 52 エスケープ + Base64 (自前実装、依存追加なし) + tmux DCS ラップ
- `src/command.rs`: `Command::CopyToClipboard(String)` 追加
- `src/action.rs` + `src/keymap.rs`: `Action::CopyUrl` を `DetailContent` と `CommentList` で `y` にバインド
- `src/app_state/`: `toast: Option<String>` を追加、`copy_current_card_url` / `copy_current_comment_url` を実装、次のキー入力で toast をクリア
- `src/app.rs`: `Command::CopyToClipboard` を stdout 経由の `write_osc52` に繋ぐ
- `src/ui/statusline.rs`: toast を緑で右端に描画 (loading > toast > update の優先順)
- GraphQL: 5 本のクエリ/ミューテーションに `url` を追加し、`Comment { url: Option<String> }` に反映 (旧キャッシュ互換で `#[serde(default)]`)
- `src/ui/help.rs` + `locales/*.yml`: ヘルプに `copy_url` を日英両方で追加
- `CLAUDE.md`: 詳細ビューのキー一覧に `y` を追記

## Tests
- AppState 側: 4 件追加 (カード URL コピー / URL なし時 no-op / コメント URL コピー / toast クリア)
- Clipboard ヘルパー: 6 件追加 (Base64 既知ベクタ / OSC 52 フォーマット / 書き出し / tmux ラップでの ESC 二重化 / 内外の分岐)
- 既存テスト含め `cargo test` 430 件 pass、`cargo clippy -- -D warnings` クリーン

## Test plan
- [ ] iTerm2 or Ghostty 単体で `y` を押すとクリップボードに URL が入る
- [ ] tmux 配下 (ghostty) でも同様にコピーできる
- [ ] コメント一覧でカーソル行を動かしたあと `y` で permalink がコピーされる
- [ ] ステータスライン右端に緑の `Copied URL: ...` が一瞬表示され、次のキーで消える
- [ ] URL を持たない DraftIssue で `y` を押しても落ちない / no-op

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)