### PR TITLE
feat(draft): draft Issue を実 Issue にコンバートする (i キー)

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -17,6 +17,7 @@ help:
     next_tab: "Next column (wrap)"
     grab_card: "Grab card (move mode)"
     new_card: "New card (draft/issue)"
+    convert_draft_to_issue: "Convert draft to real issue"
     archive_card: "Archive card"
     show_archived_list: "Open archive page in browser"
     bulk_select: "Bulk select mode (Space:toggle *:all a:archive H/L:move)"

--- a/locales/ja.yml
+++ b/locales/ja.yml
@@ -17,6 +17,7 @@ help:
     next_tab: "次のカラム (ラップ)"
     grab_card: "カードを掴む (移動モード)"
     new_card: "新規カード (draft/issue)"
+    convert_draft_to_issue: "Draft を Issue にコンバート"
     archive_card: "カードをアーカイブ"
     show_archived_list: "アーカイブ一覧をブラウザで開く"
     bulk_select: "一括選択モード (Space:選択 *:全選択 a:アーカイブ H/L:移動)"

--- a/src/action.rs
+++ b/src/action.rs
@@ -19,6 +19,7 @@ pub enum Action {
     OpenDetail,
     GrabCard,
     NewCard,
+    ConvertDraftToIssue,
     ArchiveCard,
     ShowArchivedList,
     StartFilter,

--- a/src/app.rs
+++ b/src/app.rs
@@ -255,6 +255,24 @@ impl App {
                     ));
                 });
             }
+            Command::ConvertDraftToIssue {
+                project_id: _,
+                item_id,
+                repository_id,
+            } => {
+                let client = self.github.clone();
+                let tx = self.event_tx.clone();
+                tokio::spawn(async move {
+                    let result = client
+                        .convert_draft_to_issue(&item_id, &repository_id)
+                        .await
+                        .map(|_| ());
+                    let _ = tx.send(AppEvent::Mutated(
+                        MutationKind::DraftConverted,
+                        result.map_err(|e| e.to_string()),
+                    ));
+                });
+            }
             Command::CreateCard {
                 project_id,
                 title,

--- a/src/app_state/detail.rs
+++ b/src/app_state/detail.rs
@@ -138,6 +138,7 @@ impl AppState {
                 Command::None
             }
             Action::EditCard => self.start_edit_card(),
+            Action::ConvertDraftToIssue => self.start_convert_draft_to_issue(),
             Action::NewComment => self.start_new_comment(),
             Action::OpenCommentList => self.open_comment_list(),
             Action::OpenReactionPicker => self.open_reaction_picker_for_card(),

--- a/src/app_state/mod.rs
+++ b/src/app_state/mod.rs
@@ -14,8 +14,8 @@ use crate::model::state::{
     ActiveFilter, CommentListState, ConfirmAction, ConfirmState, CreateCardField,
     CreateCardState, DetailPane, EditCardField, EditCardState, EditItem, FilterCondition,
     FilterState, GrabState, GroupBySelectState, LayoutMode, LoadingState, NewCardType,
-    PendingIssueCreate, ReactionPickerState, ReactionTarget, RepoSelectState, Scene,
-    SidebarEditMode, SidebarSection, ViewMode,
+    PendingIssueCreate, ReactionPickerState, ReactionTarget, RepoSelectAction, RepoSelectState,
+    Scene, SidebarEditMode, SidebarSection, ViewMode,
 };
 #[cfg(test)]
 use crate::model::state::{SIDEBAR_ASSIGNEES, SIDEBAR_LABELS};
@@ -369,8 +369,8 @@ impl AppState {
         result: Result<(), String>,
     ) -> Command {
         match (kind, result) {
-            // CardCreated の Ok は新しいカードを反映するためリロード
-            (MutationKind::CardCreated, Ok(())) => {
+            // CardCreated / DraftConverted の Ok は新しい状態を反映するためリロード
+            (MutationKind::CardCreated | MutationKind::DraftConverted, Ok(())) => {
                 if let Some(project) = &self.current_project {
                     let id = project.id.clone();
                     self.start_loading_board(&id)
@@ -998,6 +998,7 @@ impl AppState {
                 self.mode = ViewMode::CreateCard;
                 Some(Command::None)
             }
+            Action::ConvertDraftToIssue => Some(self.start_convert_draft_to_issue()),
             Action::BulkSelectStart => {
                 self.enter_bulk_select();
                 Some(Command::None)
@@ -2674,7 +2675,10 @@ mod tests {
         assert!(state.repo_select_state().is_some());
         let rs = state.repo_select_state().unwrap();
         assert_eq!(rs.selected_index, 0);
-        assert_eq!(rs.pending_create.title, "My Issue");
+        let RepoSelectAction::CreateIssue(pending) = &rs.action else {
+            panic!("expected CreateIssue action");
+        };
+        assert_eq!(pending.title, "My Issue");
     }
 
     #[test]
@@ -2923,9 +2927,12 @@ mod tests {
 
         // RepoSelect に積まれた pending_create が filter 由来の値を保持していること
         let rs = state.repo_select_state().expect("repo select active");
-        assert_eq!(rs.pending_create.initial_label_names, vec!["bug".to_string()]);
+        let RepoSelectAction::CreateIssue(pending) = &rs.action else {
+            panic!("expected CreateIssue action");
+        };
+        assert_eq!(pending.initial_label_names, vec!["bug".to_string()]);
         assert_eq!(
-            rs.pending_create.initial_assignee_logins,
+            pending.initial_assignee_logins,
             vec!["alice".to_string()]
         );
     }
@@ -2958,7 +2965,7 @@ mod tests {
         let mut state = make_state_with_board(board);
         state.enter_repo_select(RepoSelectState {
             selected_index: 0,
-            pending_create: PendingIssueCreate {
+            action: RepoSelectAction::CreateIssue(PendingIssueCreate {
                 title: "My Issue".into(),
                 body: "body".into(),
                 initial_status: Some(crate::command::InitialStatus {
@@ -2967,7 +2974,7 @@ mod tests {
                 }),
                 initial_label_names: vec![],
                 initial_assignee_logins: vec![],
-            },
+            }),
         });
         state
     }
@@ -3028,6 +3035,154 @@ mod tests {
 
         assert_eq!(state.mode, ViewMode::Board);
         assert!(state.repo_select_state().is_none());
+    }
+
+    // ========== Draft → Issue 変換 ==========
+
+    fn make_draft_card_simple(item_id: &str, title: &str) -> Card {
+        let mut c = make_card(item_id, title);
+        c.card_type = CardType::DraftIssue;
+        c
+    }
+
+    fn make_open_issue_card(item_id: &str, title: &str) -> Card {
+        let mut c = make_card(item_id, title);
+        c.card_type = CardType::Issue {
+            state: crate::model::project::IssueState::Open,
+        };
+        c.content_id = Some(format!("issue_{item_id}"));
+        c
+    }
+
+    #[test]
+    fn test_convert_draft_single_repo_dispatches_command_directly() {
+        let board = make_board_with_repos(
+            vec![("Todo", "opt_1", vec![make_draft_card_simple("d1", "Draft A")])],
+            vec![("repo_1", "owner/repo")],
+        );
+        let mut state = make_state_with_board(board);
+        state.selected_column = 0;
+        state.selected_card = 0;
+
+        let cmd = state.handle_event(AppEvent::Key(key(KeyCode::Char('i'))));
+
+        assert_eq!(
+            cmd,
+            Command::ConvertDraftToIssue {
+                project_id: "proj_1".into(),
+                item_id: "d1".into(),
+                repository_id: "repo_1".into(),
+            }
+        );
+        assert_eq!(state.mode, ViewMode::Board);
+    }
+
+    #[test]
+    fn test_convert_draft_multiple_repos_opens_repo_select() {
+        let board = make_board_with_repos(
+            vec![("Todo", "opt_1", vec![make_draft_card_simple("d1", "Draft A")])],
+            vec![("repo_1", "owner/repo1"), ("repo_2", "owner/repo2")],
+        );
+        let mut state = make_state_with_board(board);
+        state.selected_column = 0;
+        state.selected_card = 0;
+
+        let cmd = state.handle_event(AppEvent::Key(key(KeyCode::Char('i'))));
+        assert_eq!(cmd, Command::None);
+        assert_eq!(state.mode, ViewMode::RepoSelect);
+
+        let rs = state.repo_select_state().expect("repo select active");
+        match &rs.action {
+            RepoSelectAction::ConvertDraft { item_id, title } => {
+                assert_eq!(item_id, "d1");
+                assert_eq!(title, "Draft A");
+            }
+            other => panic!("expected ConvertDraft action, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_convert_draft_repo_select_enter_dispatches_convert_command() {
+        let board = make_board_with_repos(
+            vec![("Todo", "opt_1", vec![make_draft_card_simple("d1", "Draft A")])],
+            vec![("repo_1", "owner/repo1"), ("repo_2", "owner/repo2")],
+        );
+        let mut state = make_state_with_board(board);
+        state.selected_column = 0;
+        state.selected_card = 0;
+        state.handle_event(AppEvent::Key(key(KeyCode::Char('i'))));
+        assert_eq!(state.mode, ViewMode::RepoSelect);
+
+        // 2 番目のリポジトリを選択して Enter
+        state.handle_event(AppEvent::Key(key(KeyCode::Char('j'))));
+        let cmd = state.handle_event(AppEvent::Key(key(KeyCode::Enter)));
+
+        assert_eq!(
+            cmd,
+            Command::ConvertDraftToIssue {
+                project_id: "proj_1".into(),
+                item_id: "d1".into(),
+                repository_id: "repo_2".into(),
+            }
+        );
+        assert_eq!(state.mode, ViewMode::Board);
+        assert!(state.repo_select_state().is_none());
+    }
+
+    #[test]
+    fn test_convert_draft_on_issue_card_is_no_op() {
+        // Issue (実 issue) に対して i を押しても何も起きない
+        let board = make_board_with_repos(
+            vec![("Todo", "opt_1", vec![make_open_issue_card("i1", "Issue A")])],
+            vec![("repo_1", "owner/repo")],
+        );
+        let mut state = make_state_with_board(board);
+        state.selected_column = 0;
+        state.selected_card = 0;
+
+        let cmd = state.handle_event(AppEvent::Key(key(KeyCode::Char('i'))));
+        assert_eq!(cmd, Command::None);
+        assert_eq!(state.mode, ViewMode::Board);
+    }
+
+    #[test]
+    fn test_convert_draft_no_repos_shows_error() {
+        let board = make_board(vec![(
+            "Todo",
+            "opt_1",
+            vec![make_draft_card_simple("d1", "Draft A")],
+        )]);
+        let mut state = make_state_with_board(board);
+        state.selected_column = 0;
+        state.selected_card = 0;
+
+        let cmd = state.handle_event(AppEvent::Key(key(KeyCode::Char('i'))));
+        assert_eq!(cmd, Command::None);
+        assert!(matches!(state.loading, LoadingState::Error(_)));
+    }
+
+    #[test]
+    fn test_convert_draft_from_detail_view_dispatches() {
+        let board = make_board_with_repos(
+            vec![("Todo", "opt_1", vec![make_draft_card_simple("d1", "Draft A")])],
+            vec![("repo_1", "owner/repo")],
+        );
+        let mut state = make_state_with_board(board);
+        state.selected_column = 0;
+        state.selected_card = 0;
+        state.mode = ViewMode::Detail;
+        state.detail_pane = DetailPane::Content;
+
+        let cmd = state.handle_event(AppEvent::Key(key(KeyCode::Char('i'))));
+
+        assert_eq!(
+            cmd,
+            Command::ConvertDraftToIssue {
+                project_id: "proj_1".into(),
+                item_id: "d1".into(),
+                repository_id: "repo_1".into(),
+            }
+        );
     }
 
     // ========== Body: $EDITOR ==========

--- a/src/app_state/modal.rs
+++ b/src/app_state/modal.rs
@@ -208,6 +208,73 @@ impl AppState {
         }
     }
 
+    /// 現在選択中のカードが Draft Issue であれば、convertProjectV2DraftIssueItemToIssue で
+    /// 実 Issue にコンバートする。リポジトリが 1 つなら直接 Command を返し、複数あれば
+    /// RepoSelect モーダルを開く。
+    pub(super) fn start_convert_draft_to_issue(&mut self) -> Command {
+        // detail_stack 上の Issue (ボード外) はコンバート対象外
+        if !self.detail_stack.is_empty() {
+            return Command::None;
+        }
+
+        let real_idx = match self.real_card_index() {
+            Some(idx) => idx,
+            None => return Command::None,
+        };
+
+        let card = match self
+            .board
+            .as_ref()
+            .and_then(|b| b.columns.get(self.selected_column))
+            .and_then(|c| c.cards.get(real_idx))
+        {
+            Some(c) => c,
+            None => return Command::None,
+        };
+
+        // Draft 以外は no-op
+        if !matches!(card.card_type, CardType::DraftIssue) {
+            return Command::None;
+        }
+
+        let item_id = card.item_id.clone();
+        let title = card.title.clone();
+
+        let project_id = match &self.current_project {
+            Some(p) => p.id.clone(),
+            None => return Command::None,
+        };
+
+        let repos = self
+            .board
+            .as_ref()
+            .map(|b| &b.repositories)
+            .cloned()
+            .unwrap_or_default();
+
+        if repos.is_empty() {
+            self.loading =
+                LoadingState::Error("No repositories linked to this project.".into());
+            return Command::None;
+        }
+
+        if repos.len() == 1 {
+            self.mode = ViewMode::Board;
+            self.loading = LoadingState::Loading("Converting draft to issue...".into());
+            return Command::ConvertDraftToIssue {
+                project_id,
+                item_id,
+                repository_id: repos[0].id.clone(),
+            };
+        }
+
+        self.enter_repo_select(RepoSelectState {
+            selected_index: 0,
+            action: super::RepoSelectAction::ConvertDraft { item_id, title },
+        });
+        Command::None
+    }
+
     pub(super) fn show_archived_list(&mut self) -> Command {
         // GitHub Projects V2 の GraphQL API では archived item を取得する手段が
         // 存在しない (items() の query 引数では `is:archived` が効かず、未指定時も
@@ -305,13 +372,13 @@ impl AppState {
                 // 複数リポジトリ → セレクタ表示
                 self.enter_repo_select(RepoSelectState {
                     selected_index: 0,
-                    pending_create: PendingIssueCreate {
+                    action: super::RepoSelectAction::CreateIssue(PendingIssueCreate {
                         title,
                         body,
                         initial_status,
                         initial_label_names,
                         initial_assignee_logins,
-                    },
+                    }),
                 });
                 Command::None
             }
@@ -380,17 +447,29 @@ impl AppState {
         };
 
         self.mode = ViewMode::Board;
-        self.loading = LoadingState::Loading("Creating issue...".into());
 
-        Command::CreateIssue {
-            project_id,
-            repository_id: repo.id,
-            repository_name_with_owner: repo.name_with_owner,
-            title: rs.pending_create.title,
-            body: rs.pending_create.body,
-            initial_status: rs.pending_create.initial_status,
-            initial_label_names: rs.pending_create.initial_label_names,
-            initial_assignee_logins: rs.pending_create.initial_assignee_logins,
+        match rs.action {
+            super::RepoSelectAction::CreateIssue(pending) => {
+                self.loading = LoadingState::Loading("Creating issue...".into());
+                Command::CreateIssue {
+                    project_id,
+                    repository_id: repo.id,
+                    repository_name_with_owner: repo.name_with_owner,
+                    title: pending.title,
+                    body: pending.body,
+                    initial_status: pending.initial_status,
+                    initial_label_names: pending.initial_label_names,
+                    initial_assignee_logins: pending.initial_assignee_logins,
+                }
+            }
+            super::RepoSelectAction::ConvertDraft { item_id, .. } => {
+                self.loading = LoadingState::Loading("Converting draft to issue...".into());
+                Command::ConvertDraftToIssue {
+                    project_id,
+                    item_id,
+                    repository_id: repo.id,
+                }
+            }
         }
     }
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -32,6 +32,13 @@ pub enum Command {
         project_id: String,
         item_id: String,
     },
+    /// Draft Issue (ProjectV2DraftIssue) を実 Issue にコンバートする。
+    /// `convertProjectV2DraftIssueItemToIssue` mutation を呼び、完了後にボードをリフレッシュする。
+    ConvertDraftToIssue {
+        project_id: String,
+        item_id: String,
+        repository_id: String,
+    },
     CreateCard {
         project_id: String,
         title: String,

--- a/src/event.rs
+++ b/src/event.rs
@@ -25,6 +25,8 @@ pub enum MutationKind {
     CustomFieldUpdated,
     ReactionToggled,
     CardCreated,
+    /// Draft Issue を実 Issue にコンバートした (ボードの楽観的更新は不可なので必ずリフレッシュ)
+    DraftConverted,
 }
 
 pub enum AppEvent {

--- a/src/github/client/mutations.rs
+++ b/src/github/client/mutations.rs
@@ -155,6 +155,23 @@ impl GitHubClient {
         Ok(item.id)
     }
 
+    pub async fn convert_draft_to_issue(
+        &self,
+        item_id: &str,
+        repository_id: &str,
+    ) -> anyhow::Result<String> {
+        let vars = convert_draft_issue::Variables {
+            item_id: item_id.to_string(),
+            repository_id: repository_id.to_string(),
+        };
+        let data = self.query::<ConvertDraftIssue>(vars).await?;
+        let item = data
+            .convert_project_v2_draft_issue_item_to_issue
+            .and_then(|p| p.item)
+            .context("Failed to convert draft issue to issue")?;
+        Ok(item.id)
+    }
+
     pub async fn add_labels(
         &self,
         content_id: &str,

--- a/src/github/graphql/convert_draft_issue.graphql
+++ b/src/github/graphql/convert_draft_issue.graphql
@@ -1,0 +1,9 @@
+mutation ConvertDraftIssue($itemId: ID!, $repositoryId: ID!) {
+  convertProjectV2DraftIssueItemToIssue(
+    input: { itemId: $itemId, repositoryId: $repositoryId }
+  ) {
+    item {
+      id
+    }
+  }
+}

--- a/src/github/queries.rs
+++ b/src/github/queries.rs
@@ -252,3 +252,11 @@ pub struct RemoveReactionMutation;
     response_derives = "Debug"
 )]
 pub struct FetchCardDetail;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "schema.graphql",
+    query_path = "src/github/graphql/convert_draft_issue.graphql",
+    response_derives = "Debug"
+)]
+pub struct ConvertDraftIssue;

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -222,6 +222,7 @@ impl Keymap {
         board.insert(KeyBind::char('A'), Action::ShowArchivedList);
         board.insert(KeyBind::char('v'), Action::BulkSelectStart);
         board.insert(KeyBind::char('n'), Action::NewCard);
+        board.insert(KeyBind::char('i'), Action::ConvertDraftToIssue);
         board.insert(KeyBind::char(' '), Action::GrabCard);
         board.insert(KeyBind::ctrl('g'), Action::ChangeGrouping);
         board.insert(KeyBind::char('t'), Action::ToggleLayout);
@@ -247,6 +248,7 @@ impl Keymap {
         table.insert(KeyBind::char('A'), Action::ShowArchivedList);
         table.insert(KeyBind::char('v'), Action::BulkSelectStart);
         table.insert(KeyBind::char('n'), Action::NewCard);
+        table.insert(KeyBind::char('i'), Action::ConvertDraftToIssue);
         table.insert(KeyBind::char(' '), Action::GrabCard);
         table.insert(KeyBind::ctrl('g'), Action::ChangeGrouping);
         table.insert(KeyBind::char('t'), Action::ToggleLayout);
@@ -372,6 +374,7 @@ impl Keymap {
         detail_content.insert(KeyBind::char('l'), Action::MoveRight);
         detail_content.insert(KeyBind::key(KeyCode::Right), Action::MoveRight);
         detail_content.insert(KeyBind::char('e'), Action::EditCard);
+        detail_content.insert(KeyBind::char('i'), Action::ConvertDraftToIssue);
         detail_content.insert(KeyBind::char('c'), Action::NewComment);
         detail_content.insert(KeyBind::char('C'), Action::OpenCommentList);
         detail_content.insert(KeyBind::char('r'), Action::OpenReactionPicker);
@@ -624,6 +627,7 @@ fn parse_action_name(name: &str) -> Option<Action> {
         "open_detail" => Some(Action::OpenDetail),
         "grab_card" => Some(Action::GrabCard),
         "new_card" => Some(Action::NewCard),
+        "convert_draft_to_issue" => Some(Action::ConvertDraftToIssue),
         "archive_card" => Some(Action::ArchiveCard),
         "show_archived_list" => Some(Action::ShowArchivedList),
         "start_filter" => Some(Action::StartFilter),
@@ -681,6 +685,7 @@ pub fn action_name(action: Action) -> &'static str {
         Action::OpenDetail => "open_detail",
         Action::GrabCard => "grab_card",
         Action::NewCard => "new_card",
+        Action::ConvertDraftToIssue => "convert_draft_to_issue",
         Action::ArchiveCard => "archive_card",
         Action::ShowArchivedList => "show_archived_list",
         Action::StartFilter => "start_filter",

--- a/src/model/state.rs
+++ b/src/model/state.rs
@@ -237,7 +237,16 @@ pub enum ReactionTarget {
 #[derive(Clone, Debug)]
 pub struct RepoSelectState {
     pub selected_index: usize,
-    pub pending_create: PendingIssueCreate,
+    pub action: RepoSelectAction,
+}
+
+#[derive(Clone, Debug)]
+pub enum RepoSelectAction {
+    /// CreateCard モーダル経由の新規 Issue 作成
+    CreateIssue(PendingIssueCreate),
+    /// Draft Issue を Issue にコンバート (convertProjectV2DraftIssueItemToIssue)。
+    /// `title` はモーダルに「Convert "<title>" → Issue」と表示するためだけに保持する。
+    ConvertDraft { item_id: String, title: String },
 }
 
 #[derive(Clone, Debug)]

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -94,6 +94,7 @@ pub fn render(frame: &mut Frame, area: Rect, keymap: &Keymap) {
     let action_entries = vec![
         entry(Action::GrabCard, "help.entries.grab_card"),
         entry(Action::NewCard, "help.entries.new_card"),
+        entry(Action::ConvertDraftToIssue, "help.entries.convert_draft_to_issue"),
         entry(Action::ArchiveCard, "help.entries.archive_card"),
         entry(Action::ShowArchivedList, "help.entries.show_archived_list"),
         entry(Action::BulkSelectStart, "help.entries.bulk_select"),
@@ -122,6 +123,7 @@ pub fn render(frame: &mut Frame, area: Rect, keymap: &Keymap) {
         entry(Action::OpenInBrowser, "help.entries.open_in_browser"),
         entry(Action::CopyUrl, "help.entries.copy_url"),
         entry(Action::EditCard, "help.entries.edit_card"),
+        entry(Action::ConvertDraftToIssue, "help.entries.convert_draft_to_issue"),
         entry(Action::NewComment, "help.entries.new_comment"),
         entry(Action::OpenCommentList, "help.entries.open_comment_list"),
         entry(Action::OpenReactionPicker, "help.entries.toggle_reaction"),

--- a/src/ui/repo_select.rs
+++ b/src/ui/repo_select.rs
@@ -7,7 +7,7 @@ use ratatui::{
 };
 
 use crate::model::project::Repository;
-use crate::model::state::RepoSelectState;
+use crate::model::state::{RepoSelectAction, RepoSelectState};
 use crate::ui::layout::modal_area_fixed;
 use crate::ui::theme::theme;
 
@@ -16,8 +16,14 @@ pub fn render(frame: &mut Frame, area: Rect, repos: &[Repository], state: &RepoS
     let popup = modal_area_fixed(50, height, area);
     frame.render_widget(Clear, popup);
 
+    let title: String = match &state.action {
+        RepoSelectAction::CreateIssue(_) => " Select Repository ".into(),
+        RepoSelectAction::ConvertDraft { title, .. } => {
+            format!(" Convert \"{title}\" → Issue: Select Repository ")
+        }
+    };
     let block = Block::default()
-        .title(" Select Repository ")
+        .title(title)
         .title_style(
             Style::default()
                 .fg(theme().accent)


### PR DESCRIPTION
## Summary
- カード詳細やボード上で `i` を押すと、選択中の draft-issue を `convertProjectV2DraftIssueItemToIssue` mutation で実 Issue にコンバートする
- リポジトリが 1 つなら直接実行、複数なら既存の `RepoSelect` モーダルを再利用してリポジトリを選ばせる (タイトル表示で「Convert "<title>" → Issue」と区別)
- 完了後はボードをリフレッシュ (`MutationKind::DraftConverted`) してコンバート結果を反映
- Help / locales (ja/en) にも `convert_draft_to_issue` を追加

## Test plan
- [x] `cargo test` (440 passed、新規 6 ケース含む)
- [x] `cargo clippy -- -D warnings` クリーン
- [ ] 実環境で draft → issue コンバートを確認 (single repo)
- [ ] 実環境で複数 repo プロジェクトで RepoSelect → コンバートを確認
- [ ] Issue カード/PR カードで `i` が no-op であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)