### PR TITLE
feat(commands): config 経由のカスタムコマンドを実行可能に

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,6 +214,16 @@ assert_eq!(cmd, Command::MoveCard { ... });
 - `cargo test` で全テストが通ることを確認してからコミットする
 - 実装完了後は `cargo clippy -- -D warnings` も実行し、警告がないことを確認する (CI で同じチェックが走る)
 
+### カスタムコマンド (`[[command]]`)
+- `~/.config/gh-board/config.toml` の `[[command]]` で定義した shell snippet を、選択中のカードを context にして実行する
+- 各 entry: `name` / `command` / `key`(任意) / `interactive`(default true) / `description`(任意)
+- `command` 内の `{number}` `{title}` `{url}` `{owner}` `{repo}` `{name_with_owner}` `{id}` `{content_id}` `{item_id}` `{body}` `{card_type}` `{project_number}` `{project_title}` `{project_url}` が `src/app_state/custom_command.rs::expand_placeholders` で展開される。未対応 key は `{...}` のまま残る (将来拡張に安全)
+- 発火経路:
+  - `key` が登録されたエントリは `Keymap::register_custom_commands` で `global` に bind され、Board / Detail から直接発動
+  - Board / Detail の `:` で `ViewMode::CommandPalette` を開き、j/k で選択 → Enter で発動 (`src/ui/command_palette.rs`)
+- 実行は `Command::RunCustomCommand { name, command_line, interactive }` を返し、`interactive = true` の場合は `App.pending_custom_command` に積んで `main.rs` 側で `$EDITOR` と同様に TUI 一時停止 + `sh -c <command_line>` を foreground 実行 → 完了 toast を表示する。`interactive = false` の場合は `tokio::spawn` でバックグラウンド実行 (stdio は捨てる)
+- AppState は `custom_commands: Vec<CustomCommandConfig>` を保持 (`set_custom_commands`)
+
 ## i18n (ヘルプ画面のみ)
 
 - `rust-i18n` v3 でコンパイル時に `locales/*.yml` を埋め込み、`src/ui/help.rs` でのみ `t!("key")` を使う

--- a/README.ja.md
+++ b/README.ja.md
@@ -182,6 +182,43 @@ filter = "assignee:@me"
 layout = "table"
 ```
 
+### カスタムコマンド
+
+`~/.config/gh-board/config.toml` にシェルコマンドを定義しておき、現在選択中のカードを文脈にして実行できます。割り当てた `key` で直接実行するほか、Board / Detail 画面で `:` を押すとパレットが開き一覧から選択できます。
+
+```toml
+[[command]]
+name = "Resolve with Claude"
+command = "git worktree add ../{repo}.resolve-{number} -b resolve-{number} && cd ../{repo}.resolve-{number} && claude 'https://github.com/{owner}/{repo}/issues/{number} を解決してください'"
+key = "C-r"
+description = "worktree を作って claude を起動する"
+
+[[command]]
+name = "Copy issue ref"
+command = "printf '#%s' '{number}' | pbcopy"
+interactive = false
+```
+
+利用可能なプレースホルダ (選択中のカード / プロジェクトから解決):
+
+| プレースホルダ | 説明 |
+|---|---|
+| `{number}` | Issue / PR 番号 |
+| `{title}` | カードタイトル |
+| `{url}` | カード URL |
+| `{body}` | カード本文 (Markdown) |
+| `{owner}` / `{repo}` / `{name_with_owner}` | カード URL からパース |
+| `{id}` / `{content_id}` | Issue / PR の node id |
+| `{item_id}` | プロジェクトアイテム id |
+| `{card_type}` | `issue` / `pull_request` / `draft_issue` |
+| `{project_number}` / `{project_title}` / `{project_url}` | 現在のプロジェクト情報 |
+
+ポイント:
+- `command` は `sh -c` で実行されます。`&&` や `|` なども普通に書けます。
+- `interactive = true` (デフォルト) は `$EDITOR` と同じく TUI を一時停止して foreground で実行します (claude や vim のようにターミナルを占有するツール向け)。`interactive = false` の場合はバックグラウンドで spawn され、stdout/stderr は破棄されます。
+- カードに対応する値が無いプレースホルダ (例: Draft Issue の `{number}`) は空文字列に展開されます。未知のプレースホルダはそのまま残るので、独自テンプレートにも安全に使えます。
+- `key` を指定していないコマンドも `:` パレットから実行できます。
+
 ## ビルド
 
 ```

--- a/README.md
+++ b/README.md
@@ -182,6 +182,43 @@ filter = "assignee:@me"
 layout = "table"
 ```
 
+### Custom Commands
+
+Define shell snippets in `~/.config/gh-board/config.toml` and run them against the currently selected card. Trigger a command either by its bound key, or open the palette with `:` (on the Board or Detail screen) and pick from the list.
+
+```toml
+[[command]]
+name = "Resolve with Claude"
+command = "git worktree add ../{repo}.resolve-{number} -b resolve-{number} && cd ../{repo}.resolve-{number} && claude 'https://github.com/{owner}/{repo}/issues/{number} を解決してください'"
+key = "C-r"
+description = "Spawn a worktree and launch claude inside"
+
+[[command]]
+name = "Copy issue ref"
+command = "printf '#%s' '{number}' | pbcopy"
+interactive = false
+```
+
+Available placeholders (resolved from the selected card / current project):
+
+| Placeholder | Description |
+|---|---|
+| `{number}` | Issue / PR number |
+| `{title}` | Card title |
+| `{url}` | Card URL |
+| `{body}` | Card body (Markdown) |
+| `{owner}` / `{repo}` / `{name_with_owner}` | Parsed from the card URL |
+| `{id}` / `{content_id}` | Issue / PR node id |
+| `{item_id}` | Project item id |
+| `{card_type}` | `issue` / `pull_request` / `draft_issue` |
+| `{project_number}` / `{project_title}` / `{project_url}` | Current project info |
+
+Notes:
+- `command` is executed via `sh -c`, so you can chain with `&&`, `|`, etc.
+- `interactive = true` (default) suspends the TUI like `$EDITOR` does — required for tools that take over the terminal (e.g. `claude`, `vim`). `interactive = false` runs the command in the background and discards its output.
+- Placeholders for fields the card does not have (e.g. `{number}` on a draft issue) expand to an empty string. Unknown placeholders are left intact so you can compose your own templates safely.
+- Commands without a `key` are still reachable via the `:` palette.
+
 ## Building
 
 ```

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -31,6 +31,7 @@ help:
     refresh: "Refresh"
     show_help: "Toggle help"
     quit: "Quit"
+    open_command_palette: "Open custom command palette"
     detail_scroll: "Scroll"
     detail_table_scroll: "Table scroll"
     detail_switch_sidebar: "Switch to sidebar"

--- a/locales/ja.yml
+++ b/locales/ja.yml
@@ -31,6 +31,7 @@ help:
     refresh: "リフレッシュ"
     show_help: "ヘルプ切替"
     quit: "終了"
+    open_command_palette: "カスタムコマンドパレットを開く"
     detail_scroll: "スクロール"
     detail_table_scroll: "テーブル横スクロール"
     detail_switch_sidebar: "サイドバーへ"

--- a/src/action.rs
+++ b/src/action.rs
@@ -63,4 +63,11 @@ pub enum Action {
     BulkArchive,
     BulkMoveLeft,
     BulkMoveRight,
+
+    // Custom commands
+    /// `[[command]]` で定義された config index 番目のコマンドを発火する。
+    /// パレット経由でも同じ発火に最終的に行き着く。
+    RunCustomCommand(u8),
+    /// コマンドパレット (`:`) を開く。
+    OpenCommandPalette,
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -15,6 +15,9 @@ pub struct App {
     pub state: AppState,
     pub pending_editor: Option<String>,
     pub pending_comment_editor: Option<CommentEditorContext>,
+    /// Interactive custom command を実行するため、メインループに引き渡す pending エントリ。
+    /// main.rs が pending を見つけたら TUI を一時停止し、`sh -c <command_line>` を foreground 実行する。
+    pub pending_custom_command: Option<PendingCustomCommand>,
     github: GitHubClient,
     event_tx: mpsc::UnboundedSender<AppEvent>,
     cache: DiskCache,
@@ -40,6 +43,7 @@ impl App {
             state,
             pending_editor: None,
             pending_comment_editor: None,
+            pending_custom_command: None,
             github,
             event_tx,
             cache,
@@ -669,8 +673,37 @@ impl App {
                     self.execute(cmd);
                 }
             }
+            Command::RunCustomCommand {
+                name,
+                command_line,
+                interactive,
+            } => {
+                if interactive {
+                    self.pending_custom_command = Some(PendingCustomCommand {
+                        name,
+                        command_line,
+                    });
+                } else {
+                    tokio::spawn(async move {
+                        let _ = tokio::process::Command::new("sh")
+                            .arg("-c")
+                            .arg(&command_line)
+                            .stdin(std::process::Stdio::null())
+                            .stdout(std::process::Stdio::null())
+                            .stderr(std::process::Stdio::null())
+                            .status()
+                            .await;
+                    });
+                }
+            }
         }
     }
+}
+
+#[derive(Debug, Clone)]
+pub struct PendingCustomCommand {
+    pub name: String,
+    pub command_line: String,
 }
 
 /// AppState 処理後に App が行うキャッシュ操作。`handle_event` で event を消費する前に

--- a/src/app_state/custom_command.rs
+++ b/src/app_state/custom_command.rs
@@ -1,0 +1,391 @@
+use crossterm::event::KeyEvent;
+
+use crate::action::Action;
+use crate::command::Command;
+use crate::config::CustomCommandConfig;
+use crate::keymap::KeymapMode;
+use crate::model::project::{Card, CardType, ProjectSummary};
+use crate::model::state::{Scene, ViewMode};
+
+use super::AppState;
+
+/// `https://github.com/<owner>/<repo>/issues/<n>` のような URL から (owner, repo) を抽出する。
+/// 形式に合致しない場合 None。
+pub(crate) fn parse_owner_repo_from_url(url: &str) -> Option<(String, String)> {
+    let rest = url.strip_prefix("https://github.com/")?;
+    let mut parts = rest.splitn(3, '/');
+    let owner = parts.next()?;
+    let repo = parts.next()?;
+    if owner.is_empty() || repo.is_empty() {
+        return None;
+    }
+    Some((owner.to_string(), repo.to_string()))
+}
+
+/// `command` 内の `{key}` placeholder を展開する。未対応の key は元の `{key}` 表記のまま残す。
+/// `card` が `None` の場合、カード関連 placeholder は空文字に展開される。
+pub(crate) fn expand_placeholders(
+    template: &str,
+    card: Option<&Card>,
+    project: Option<&ProjectSummary>,
+) -> String {
+    let mut out = String::with_capacity(template.len());
+    let bytes = template.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'{'
+            && let Some(close) = template[i + 1..].find('}')
+            && let Some(value) = lookup_placeholder(&template[i + 1..i + 1 + close], card, project)
+        {
+            out.push_str(&value);
+            i += 1 + close + 1;
+            continue;
+        }
+        let ch_end = next_char_end(template, i);
+        out.push_str(&template[i..ch_end]);
+        i = ch_end;
+    }
+    out
+}
+
+fn next_char_end(s: &str, start: usize) -> usize {
+    let mut p = start + 1;
+    while p < s.len() && !s.is_char_boundary(p) {
+        p += 1;
+    }
+    p
+}
+
+fn lookup_placeholder(
+    key: &str,
+    card: Option<&Card>,
+    project: Option<&ProjectSummary>,
+) -> Option<String> {
+    let owner_repo = card
+        .and_then(|c| c.url.as_deref())
+        .and_then(parse_owner_repo_from_url);
+
+    match key {
+        "number" => Some(
+            card.and_then(|c| c.number)
+                .map(|n| n.to_string())
+                .unwrap_or_default(),
+        ),
+        "title" => Some(card.map(|c| c.title.clone()).unwrap_or_default()),
+        "url" => Some(card.and_then(|c| c.url.clone()).unwrap_or_default()),
+        "body" => Some(card.and_then(|c| c.body.clone()).unwrap_or_default()),
+        "id" | "content_id" => Some(
+            card.and_then(|c| c.content_id.clone())
+                .unwrap_or_default(),
+        ),
+        "item_id" => Some(card.map(|c| c.item_id.clone()).unwrap_or_default()),
+        "owner" => Some(
+            owner_repo
+                .as_ref()
+                .map(|(o, _)| o.clone())
+                .unwrap_or_default(),
+        ),
+        "repo" => Some(
+            owner_repo
+                .as_ref()
+                .map(|(_, r)| r.clone())
+                .unwrap_or_default(),
+        ),
+        "name_with_owner" => Some(
+            owner_repo
+                .as_ref()
+                .map(|(o, r)| format!("{o}/{r}"))
+                .unwrap_or_default(),
+        ),
+        "card_type" => Some(card_type_name(card).to_string()),
+        "project_number" => Some(
+            project
+                .map(|p| p.number.to_string())
+                .unwrap_or_default(),
+        ),
+        "project_title" => Some(project.map(|p| p.title.clone()).unwrap_or_default()),
+        "project_url" => Some(project.map(|p| p.url.clone()).unwrap_or_default()),
+        _ => None,
+    }
+}
+
+fn card_type_name(card: Option<&Card>) -> &'static str {
+    match card.map(|c| &c.card_type) {
+        Some(CardType::Issue { .. }) => "issue",
+        Some(CardType::PullRequest { .. }) => "pull_request",
+        Some(CardType::DraftIssue) => "draft_issue",
+        None => "",
+    }
+}
+
+impl AppState {
+    /// `[[command]]` を AppState にセットする。
+    pub fn set_custom_commands(&mut self, commands: Vec<CustomCommandConfig>) {
+        self.custom_commands = commands;
+    }
+
+    /// 現在の選択カード (detail スタック優先) と project を元に、`commands[idx]` を展開して
+    /// `Command::RunCustomCommand` を返す。
+    /// `idx` が範囲外の場合は `Command::None` を返す。
+    pub fn run_custom_command(&self, idx: usize) -> Command {
+        let Some(cfg) = self.custom_commands.get(idx) else {
+            return Command::None;
+        };
+        let card = self
+            .current_detail_card()
+            .or_else(|| self.selected_card_ref());
+        let project = self.current_project.as_ref();
+        let command_line = expand_placeholders(&cfg.command, card, project);
+        Command::RunCustomCommand {
+            name: cfg.name.clone(),
+            command_line,
+            interactive: cfg.interactive,
+        }
+    }
+
+    /// コマンドパレットを開く。`return_to` には呼び出し元の ViewMode (Board / Detail / CommentList) を渡す。
+    /// custom_commands が空なら何もしない (toast でユーザに伝える)。
+    pub(crate) fn open_command_palette(&mut self, return_to: ViewMode) -> Command {
+        if self.custom_commands.is_empty() {
+            self.toast = Some("No custom commands defined in config.toml".into());
+            return Command::None;
+        }
+        self.command_palette_cursor = 0;
+        self.command_palette_return_to = return_to;
+        self.mode = ViewMode::CommandPalette;
+        self.scene = Scene::CommandPalette;
+        Command::None
+    }
+
+    /// コマンドパレットを閉じて元の ViewMode に戻る。
+    pub(crate) fn close_command_palette(&mut self) {
+        let return_to = self.command_palette_return_to.clone();
+        self.mode = return_to.clone();
+        // Detail / CommentList は state を持つので、現状の scene を維持できるよう
+        // mode タグから派生させる (Detail/Board のみ。CommentList は呼び出し元が
+        // 必ず state 経由で復帰させる仕様)。
+        self.scene = match return_to {
+            ViewMode::Detail => Scene::Detail,
+            ViewMode::Board => Scene::Board,
+            // CommentList は state 必須なので一旦 Board に戻す (現状の運用上不到達)。
+            _ => Scene::Board,
+        };
+    }
+
+    pub(super) fn handle_command_palette_key(&mut self, key: KeyEvent) -> Command {
+        let action = match self.keymap.resolve(KeymapMode::CommandPalette, &key) {
+            Some(a) => a,
+            None => return Command::None,
+        };
+        let len = self.custom_commands.len();
+        match action {
+            Action::Back | Action::Quit => {
+                self.close_command_palette();
+                Command::None
+            }
+            Action::MoveDown => {
+                if len > 0 {
+                    self.command_palette_cursor =
+                        (self.command_palette_cursor + 1).min(len - 1);
+                }
+                Command::None
+            }
+            Action::MoveUp => {
+                self.command_palette_cursor = self.command_palette_cursor.saturating_sub(1);
+                Command::None
+            }
+            Action::Select => {
+                let idx = self.command_palette_cursor;
+                self.close_command_palette();
+                self.run_custom_command(idx)
+            }
+            _ => Command::None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::project::{Card, CardType, IssueState};
+
+    fn make_issue_card() -> Card {
+        Card {
+            item_id: "ITEM_1".into(),
+            content_id: Some("CONTENT_1".into()),
+            title: "Bug: foo".into(),
+            number: Some(42),
+            card_type: CardType::Issue {
+                state: IssueState::Open,
+            },
+            assignees: vec![],
+            labels: vec![],
+            url: Some("https://github.com/acme/widget/issues/42".into()),
+            body: Some("Some body".into()),
+            comments: vec![],
+            milestone: None,
+            custom_fields: vec![],
+            pr_status: None,
+            linked_prs: vec![],
+            reactions: vec![],
+            archived: false,
+            parent_issue: None,
+            sub_issues_summary: None,
+            sub_issues: vec![],
+        }
+    }
+
+    fn make_draft_card() -> Card {
+        Card {
+            item_id: "ITEM_DRAFT".into(),
+            content_id: Some("DRAFT_CID".into()),
+            title: "Draft".into(),
+            number: None,
+            card_type: CardType::DraftIssue,
+            assignees: vec![],
+            labels: vec![],
+            url: None,
+            body: None,
+            comments: vec![],
+            milestone: None,
+            custom_fields: vec![],
+            pr_status: None,
+            linked_prs: vec![],
+            reactions: vec![],
+            archived: false,
+            parent_issue: None,
+            sub_issues_summary: None,
+            sub_issues: vec![],
+        }
+    }
+
+    fn make_project() -> ProjectSummary {
+        ProjectSummary {
+            id: "PRJ".into(),
+            title: "My Project".into(),
+            number: 7,
+            description: None,
+            url: "https://github.com/users/acme/projects/7".into(),
+        }
+    }
+
+    #[test]
+    fn parse_owner_repo_basic() {
+        assert_eq!(
+            parse_owner_repo_from_url("https://github.com/acme/widget/issues/42"),
+            Some(("acme".into(), "widget".into()))
+        );
+        assert_eq!(
+            parse_owner_repo_from_url("https://github.com/acme/widget/pull/100"),
+            Some(("acme".into(), "widget".into()))
+        );
+    }
+
+    #[test]
+    fn parse_owner_repo_invalid() {
+        assert_eq!(parse_owner_repo_from_url(""), None);
+        assert_eq!(parse_owner_repo_from_url("https://example.com/a/b"), None);
+        assert_eq!(parse_owner_repo_from_url("not-a-url"), None);
+    }
+
+    #[test]
+    fn expand_basic_card_fields() {
+        let card = make_issue_card();
+        let project = make_project();
+        let out = expand_placeholders(
+            "echo number={number} title={title} url={url} repo={repo} owner={owner}",
+            Some(&card),
+            Some(&project),
+        );
+        assert_eq!(
+            out,
+            "echo number=42 title=Bug: foo url=https://github.com/acme/widget/issues/42 repo=widget owner=acme"
+        );
+    }
+
+    #[test]
+    fn expand_name_with_owner() {
+        let card = make_issue_card();
+        let out = expand_placeholders("repo={name_with_owner}", Some(&card), None);
+        assert_eq!(out, "repo=acme/widget");
+    }
+
+    #[test]
+    fn expand_id_and_item_id() {
+        let card = make_issue_card();
+        let out = expand_placeholders("id={id} item={item_id}", Some(&card), None);
+        assert_eq!(out, "id=CONTENT_1 item=ITEM_1");
+    }
+
+    #[test]
+    fn expand_with_draft_card_uses_empty_strings() {
+        let card = make_draft_card();
+        let out = expand_placeholders(
+            "n={number} url={url} owner={owner} repo={repo}",
+            Some(&card),
+            None,
+        );
+        assert_eq!(out, "n= url= owner= repo=");
+    }
+
+    #[test]
+    fn expand_unknown_placeholder_left_intact() {
+        let card = make_issue_card();
+        // 未知の placeholder は `{...}` を含めて残す (将来拡張用)
+        let out = expand_placeholders("a={number} b={mystery}", Some(&card), None);
+        assert_eq!(out, "a=42 b={mystery}");
+    }
+
+    #[test]
+    fn expand_without_card_returns_empty_for_card_fields() {
+        let project = make_project();
+        let out = expand_placeholders(
+            "n={number} t={title} p={project_number}",
+            None,
+            Some(&project),
+        );
+        assert_eq!(out, "n= t= p=7");
+    }
+
+    #[test]
+    fn expand_complex_shell_example() {
+        let card = make_issue_card();
+        let template = "git worktree add ../{repo}.resolve-{number} -b resolve-{number} && cd ../{repo}.resolve-{number} && claude '{url}'";
+        let out = expand_placeholders(template, Some(&card), None);
+        assert_eq!(
+            out,
+            "git worktree add ../widget.resolve-42 -b resolve-42 && cd ../widget.resolve-42 && claude 'https://github.com/acme/widget/issues/42'"
+        );
+    }
+
+    #[test]
+    fn expand_card_type() {
+        let card = make_issue_card();
+        let out = expand_placeholders("{card_type}", Some(&card), None);
+        assert_eq!(out, "issue");
+        let card = make_draft_card();
+        let out = expand_placeholders("{card_type}", Some(&card), None);
+        assert_eq!(out, "draft_issue");
+    }
+
+    #[test]
+    fn expand_project_fields() {
+        let project = make_project();
+        let out = expand_placeholders(
+            "#{project_number} {project_title} ({project_url})",
+            None,
+            Some(&project),
+        );
+        assert_eq!(
+            out,
+            "#7 My Project (https://github.com/users/acme/projects/7)"
+        );
+    }
+
+    #[test]
+    fn expand_brace_without_close_left_intact() {
+        let card = make_issue_card();
+        let out = expand_placeholders("hello {number broken", Some(&card), None);
+        assert_eq!(out, "hello {number broken");
+    }
+}

--- a/src/app_state/detail.rs
+++ b/src/app_state/detail.rs
@@ -143,6 +143,8 @@ impl AppState {
             Action::OpenCommentList => self.open_comment_list(),
             Action::OpenReactionPicker => self.open_reaction_picker_for_card(),
             Action::CopyUrl => self.copy_current_card_url(),
+            Action::OpenCommandPalette => self.open_command_palette(ViewMode::Detail),
+            Action::RunCustomCommand(idx) => self.run_custom_command(idx as usize),
             _ => Command::None,
         }
     }
@@ -437,6 +439,8 @@ impl AppState {
                 self.start_archive_card(ViewMode::Detail);
                 Command::None
             }
+            Action::OpenCommandPalette => self.open_command_palette(ViewMode::Detail),
+            Action::RunCustomCommand(idx) => self.run_custom_command(idx as usize),
             _ => Command::None,
         }
     }

--- a/src/app_state/mod.rs
+++ b/src/app_state/mod.rs
@@ -23,6 +23,7 @@ use crate::model::state::{SIDEBAR_ASSIGNEES, SIDEBAR_LABELS};
 
 mod board;
 mod bulk;
+mod custom_command;
 mod detail;
 mod filter;
 mod modal;
@@ -68,6 +69,7 @@ fn scene_from_mode_tag(mode: &ViewMode) -> Scene {
             Scene::Board
         }
         ViewMode::BulkSelect => Scene::BulkSelect,
+        ViewMode::CommandPalette => Scene::CommandPalette,
     }
 }
 
@@ -232,6 +234,14 @@ pub struct AppState {
     /// サイドバー編集モード (Labels / Assignees / CustomField の picker) の各 item の
     /// クリック判定領域。`ui/detail/sidebar::render_sidebar_edit` で書き戻す。
     pub sidebar_edit_item_regions: std::cell::RefCell<Vec<SidebarEditItemRegion>>,
+
+    /// `[[command]]` の定義一覧。`Action::RunCustomCommand(idx)` から index 参照される。
+    pub custom_commands: Vec<crate::config::CustomCommandConfig>,
+
+    /// コマンドパレット (`ViewMode::CommandPalette`) のカーソル位置。
+    pub command_palette_cursor: usize,
+    /// パレットを開いた際の戻り先 (`ViewMode::Board` / `ViewMode::Detail` / `ViewMode::CommentList`)。
+    pub command_palette_return_to: ViewMode,
 }
 
 /// サイドバー編集モード picker の item クリック判定領域。
@@ -332,6 +342,9 @@ impl AppState {
             detail_sidebar_regions: std::cell::RefCell::new(Vec::new()),
             detail_content_area: std::cell::Cell::new(None),
             sidebar_edit_item_regions: std::cell::RefCell::new(Vec::new()),
+            custom_commands: Vec::new(),
+            command_palette_cursor: 0,
+            command_palette_return_to: ViewMode::Board,
         }
     }
 
@@ -1567,6 +1580,8 @@ impl AppState {
                 self.enter_bulk_select();
                 Some(Command::None)
             }
+            Action::OpenCommandPalette => Some(self.open_command_palette(ViewMode::Board)),
+            Action::RunCustomCommand(idx) => Some(self.run_custom_command(idx as usize)),
             _ => None,
         }
     }
@@ -1628,6 +1643,7 @@ impl AppState {
             ViewMode::GroupBySelect => self.handle_group_by_select_key(key),
             ViewMode::ReactionPicker => self.handle_reaction_picker_key(key),
             ViewMode::BulkSelect => self.handle_bulk_select_key(key),
+            ViewMode::CommandPalette => self.handle_command_palette_key(key),
         }
     }
 
@@ -8349,5 +8365,168 @@ mod tests {
             0,
         )));
         assert_eq!(state.detail_scroll, 2);
+    }
+
+    // ========== Custom commands ==========
+
+    fn make_custom_command(name: &str, command: &str, key: Option<&str>) -> crate::config::CustomCommandConfig {
+        crate::config::CustomCommandConfig {
+            name: name.into(),
+            command: command.into(),
+            key: key.map(String::from),
+            interactive: true,
+            description: None,
+        }
+    }
+
+    fn make_state_with_issue_card_and_commands(
+        commands: Vec<crate::config::CustomCommandConfig>,
+    ) -> AppState {
+        let mut card = make_card("ITEM_1", "Bug: foo");
+        card.number = Some(42);
+        card.card_type = CardType::Issue {
+            state: crate::model::project::IssueState::Open,
+        };
+        card.url = Some("https://github.com/acme/widget/issues/42".into());
+        let board = make_board(vec![("Todo", "opt_1", vec![card])]);
+        let mut state = make_state_with_board(board);
+        state.keymap = crate::keymap::Keymap::default_keymap()
+            .register_custom_commands(&commands);
+        state.set_custom_commands(commands);
+        state
+    }
+
+    #[test]
+    fn custom_command_dispatched_via_key_binding_returns_run_command() {
+        let commands = vec![make_custom_command(
+            "Resolve",
+            "echo {number} {repo}",
+            Some("C-r"),
+        )];
+        let mut state = make_state_with_issue_card_and_commands(commands);
+
+        let cmd = state.handle_event(AppEvent::Key(key_with_mod(
+            KeyCode::Char('r'),
+            KeyModifiers::CONTROL,
+        )));
+
+        assert_eq!(
+            cmd,
+            Command::RunCustomCommand {
+                name: "Resolve".into(),
+                command_line: "echo 42 widget".into(),
+                interactive: true,
+            }
+        );
+    }
+
+    #[test]
+    fn custom_command_with_invalid_key_is_not_dispatched() {
+        let commands = vec![make_custom_command("X", "echo x", Some("totally-bogus"))];
+        let mut state = make_state_with_issue_card_and_commands(commands);
+        // 不正な key は登録されないので、普通の `j` は MoveDown のままで Command::None になる
+        let cmd = state.handle_event(AppEvent::Key(key(KeyCode::Char('j'))));
+        assert_eq!(cmd, Command::None);
+    }
+
+    #[test]
+    fn open_command_palette_via_colon() {
+        let commands = vec![
+            make_custom_command("First", "echo a", None),
+            make_custom_command("Second", "echo b", None),
+        ];
+        let mut state = make_state_with_issue_card_and_commands(commands);
+
+        state.handle_event(AppEvent::Key(key(KeyCode::Char(':'))));
+
+        assert_eq!(state.mode, ViewMode::CommandPalette);
+        assert!(matches!(state.scene, Scene::CommandPalette));
+        assert_eq!(state.command_palette_cursor, 0);
+        assert_eq!(state.command_palette_return_to, ViewMode::Board);
+    }
+
+    #[test]
+    fn command_palette_navigation_and_select() {
+        let commands = vec![
+            make_custom_command("First", "echo first", None),
+            make_custom_command("Second", "echo second-{number}", None),
+        ];
+        let mut state = make_state_with_issue_card_and_commands(commands);
+
+        state.handle_event(AppEvent::Key(key(KeyCode::Char(':'))));
+        // 下に移動 → 2 番目を選択
+        state.handle_event(AppEvent::Key(key(KeyCode::Char('j'))));
+        assert_eq!(state.command_palette_cursor, 1);
+
+        // Enter で実行
+        let cmd = state.handle_event(AppEvent::Key(key(KeyCode::Enter)));
+        assert_eq!(
+            cmd,
+            Command::RunCustomCommand {
+                name: "Second".into(),
+                command_line: "echo second-42".into(),
+                interactive: true,
+            }
+        );
+        // 元の Board モードに戻っている
+        assert_eq!(state.mode, ViewMode::Board);
+    }
+
+    #[test]
+    fn command_palette_escape_closes_without_running() {
+        let commands = vec![make_custom_command("First", "echo a", None)];
+        let mut state = make_state_with_issue_card_and_commands(commands);
+
+        state.handle_event(AppEvent::Key(key(KeyCode::Char(':'))));
+        assert_eq!(state.mode, ViewMode::CommandPalette);
+        let cmd = state.handle_event(AppEvent::Key(key(KeyCode::Esc)));
+        assert_eq!(cmd, Command::None);
+        assert_eq!(state.mode, ViewMode::Board);
+    }
+
+    #[test]
+    fn command_palette_with_no_commands_shows_toast_and_stays_in_board() {
+        let mut state = make_state_with_issue_card_and_commands(vec![]);
+        state.handle_event(AppEvent::Key(key(KeyCode::Char(':'))));
+        // パレットは開かない
+        assert_eq!(state.mode, ViewMode::Board);
+        assert!(state.toast.is_some());
+    }
+
+    #[test]
+    fn run_custom_command_out_of_range_returns_none() {
+        let state = make_state_with_issue_card_and_commands(vec![]);
+        assert_eq!(state.run_custom_command(0), Command::None);
+        assert_eq!(state.run_custom_command(99), Command::None);
+    }
+
+    #[test]
+    fn custom_command_uses_detail_stack_card_when_present() {
+        // detail_stack に積んだカードを優先することを確認
+        let commands = vec![make_custom_command("X", "echo {number}", Some("C-x"))];
+        let mut state = make_state_with_issue_card_and_commands(commands);
+
+        // detail_stack に number=100 のカードを積む
+        let mut stack_card = make_card("STK", "Stack card");
+        stack_card.number = Some(100);
+        stack_card.card_type = CardType::Issue {
+            state: crate::model::project::IssueState::Open,
+        };
+        stack_card.url = Some("https://github.com/o/r/issues/100".into());
+        state.detail_stack.push(stack_card);
+
+        let cmd = state.handle_event(AppEvent::Key(key_with_mod(
+            KeyCode::Char('x'),
+            KeyModifiers::CONTROL,
+        )));
+
+        assert_eq!(
+            cmd,
+            Command::RunCustomCommand {
+                name: "X".into(),
+                command_line: "echo 100".into(),
+                interactive: true,
+            }
+        );
     }
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,4 +1,5 @@
 #[derive(Debug, PartialEq)]
+#[allow(clippy::enum_variant_names)]
 pub enum Command {
     None,
     LoadProjects {
@@ -145,6 +146,14 @@ pub enum Command {
         field_id: String,
     },
     Batch(Vec<Command>),
+    /// ユーザ定義のシェルコマンドを実行する。
+    /// `command_line` は placeholder 展開済みの文字列で、`sh -c <command_line>` として渡される。
+    /// `interactive = true` の場合は TUI を一時停止して foreground 実行する。
+    RunCustomCommand {
+        name: String,
+        command_line: String,
+        interactive: bool,
+    },
 }
 
 #[derive(Debug, PartialEq, Clone, serde::Serialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -34,6 +34,32 @@ pub struct Config {
     pub keys: KeysConfig,
     #[serde(default)]
     pub board: BoardConfig,
+    #[serde(default, rename = "command")]
+    pub commands: Vec<CustomCommandConfig>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+/// ユーザ定義のシェルコマンド。
+/// `command` は `sh -c <command>` で実行され、現在選択中のカードから次の placeholder が展開される:
+/// `{number}` `{title}` `{url}` `{owner}` `{repo}` `{name_with_owner}` `{id}` `{item_id}` `{body}` `{project_number}` `{project_title}` `{project_url}`.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct CustomCommandConfig {
+    /// パレットや status line に表示する名前。
+    pub name: String,
+    /// `sh -c` に渡すコマンド文字列。placeholder を含められる。
+    pub command: String,
+    /// 任意のキーバインド (例: "C-r")。指定時は global keymap に登録され、Board/Detail から即時起動できる。
+    #[serde(default)]
+    pub key: Option<String>,
+    /// true の場合は TUI を一時停止して foreground 実行する ($EDITOR と同様)。default: true。
+    #[serde(default = "default_true")]
+    pub interactive: bool,
+    /// パレットや status line に表示する説明 (option)。
+    #[serde(default)]
+    pub description: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Default, Clone)]
@@ -67,6 +93,7 @@ pub struct KeysConfig {
     pub filter: HashMap<String, Vec<String>>,
     pub create_card: HashMap<String, Vec<String>>,
     pub edit_card: HashMap<String, Vec<String>>,
+    pub command_palette: HashMap<String, Vec<String>>,
 }
 
 impl KeysConfig {
@@ -93,6 +120,7 @@ impl KeysConfig {
             "filter" => self.filter.clone(),
             "create_card" => self.create_card.clone(),
             "edit_card" => self.edit_card.clone(),
+            "command_palette" => self.command_palette.clone(),
             _ => HashMap::new(),
         }
     }
@@ -531,6 +559,70 @@ refresh = ["R"]
 
         let empty = keys.section("nonexistent");
         assert!(empty.is_empty());
+    }
+
+    #[test]
+    fn test_parse_no_commands() {
+        let config: Config = toml::from_str("").unwrap();
+        assert!(config.commands.is_empty());
+    }
+
+    #[test]
+    fn test_parse_single_command_minimum() {
+        let toml = r#"
+[[command]]
+name = "Print number"
+command = "echo {number}"
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert_eq!(config.commands.len(), 1);
+        assert_eq!(config.commands[0].name, "Print number");
+        assert_eq!(config.commands[0].command, "echo {number}");
+        assert_eq!(config.commands[0].key, None);
+        // interactive defaults to true
+        assert!(config.commands[0].interactive);
+    }
+
+    #[test]
+    fn test_parse_command_with_key_and_interactive() {
+        let toml = r#"
+[[command]]
+name = "Resolve with Claude"
+command = "git worktree add ../resolve-{number} -b resolve-{number} && cd ../resolve-{number} && claude '{url}'"
+key = "C-r"
+interactive = true
+description = "Spawn claude inside a new worktree"
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert_eq!(config.commands.len(), 1);
+        assert_eq!(config.commands[0].key.as_deref(), Some("C-r"));
+        assert!(config.commands[0].interactive);
+        assert_eq!(
+            config.commands[0].description.as_deref(),
+            Some("Spawn claude inside a new worktree")
+        );
+    }
+
+    #[test]
+    fn test_parse_multiple_commands() {
+        let toml = r#"
+[[command]]
+name = "First"
+command = "echo a"
+
+[[command]]
+name = "Second"
+command = "echo b"
+key = "C-b"
+interactive = false
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert_eq!(config.commands.len(), 2);
+        assert_eq!(config.commands[0].name, "First");
+        assert!(config.commands[0].interactive);
+        assert_eq!(config.commands[1].name, "Second");
+        assert!(!config.commands[1].interactive);
+        assert_eq!(config.commands[1].key.as_deref(), Some("C-b"));
     }
 
     #[test]

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -170,6 +170,7 @@ pub enum KeymapMode {
     CreateCardGlobal,
     EditCardGlobal,
     BulkSelect,
+    CommandPalette,
 }
 
 pub struct Keymap {
@@ -228,6 +229,7 @@ impl Keymap {
         board.insert(KeyBind::char('t'), Action::ToggleLayout);
         board.insert(KeyBind::char('q'), Action::Quit);
         board.insert(KeyBind::key(KeyCode::Esc), Action::Quit);
+        board.insert(KeyBind::char(':'), Action::OpenCommandPalette);
         keymap.modes.insert(KeymapMode::Board, board);
 
         // Table mode (LayoutMode::Table 時の board ハンドラから利用)
@@ -254,6 +256,7 @@ impl Keymap {
         table.insert(KeyBind::char('t'), Action::ToggleLayout);
         table.insert(KeyBind::char('q'), Action::Quit);
         table.insert(KeyBind::key(KeyCode::Esc), Action::Quit);
+        table.insert(KeyBind::char(':'), Action::OpenCommandPalette);
         keymap.modes.insert(KeymapMode::Table, table);
 
         // Roadmap mode (LayoutMode::Roadmap 時の board ハンドラから利用)
@@ -277,6 +280,7 @@ impl Keymap {
         roadmap.insert(KeyBind::char('t'), Action::ToggleLayout);
         roadmap.insert(KeyBind::char('q'), Action::Quit);
         roadmap.insert(KeyBind::key(KeyCode::Esc), Action::Quit);
+        roadmap.insert(KeyBind::char(':'), Action::OpenCommandPalette);
         keymap.modes.insert(KeymapMode::Roadmap, roadmap);
 
         // ProjectSelect mode (文字キーはフィルタ入力に使うため割り当てない)
@@ -379,6 +383,7 @@ impl Keymap {
         detail_content.insert(KeyBind::char('C'), Action::OpenCommentList);
         detail_content.insert(KeyBind::char('r'), Action::OpenReactionPicker);
         detail_content.insert(KeyBind::char('y'), Action::CopyUrl);
+        detail_content.insert(KeyBind::char(':'), Action::OpenCommandPalette);
         keymap.modes.insert(KeymapMode::DetailContent, detail_content);
 
         // Detail sidebar
@@ -393,6 +398,7 @@ impl Keymap {
         detail_sidebar.insert(KeyBind::key(KeyCode::Up), Action::MoveUp);
         detail_sidebar.insert(KeyBind::key(KeyCode::Enter), Action::Select);
         detail_sidebar.insert(KeyBind::char('a'), Action::ArchiveCard);
+        detail_sidebar.insert(KeyBind::char(':'), Action::OpenCommandPalette);
         keymap.modes.insert(KeymapMode::DetailSidebar, detail_sidebar);
 
         // Status select dropdown
@@ -487,7 +493,37 @@ impl Keymap {
         bulk_select.insert(KeyBind::key(KeyCode::Esc), Action::BulkSelectClear);
         keymap.modes.insert(KeymapMode::BulkSelect, bulk_select);
 
+        // CommandPalette mode
+        let mut palette = HashMap::new();
+        palette.insert(KeyBind::char('j'), Action::MoveDown);
+        palette.insert(KeyBind::key(KeyCode::Down), Action::MoveDown);
+        palette.insert(KeyBind::char('k'), Action::MoveUp);
+        palette.insert(KeyBind::key(KeyCode::Up), Action::MoveUp);
+        palette.insert(KeyBind::key(KeyCode::Enter), Action::Select);
+        palette.insert(KeyBind::key(KeyCode::Esc), Action::Back);
+        palette.insert(KeyBind::char('q'), Action::Back);
+        keymap.modes.insert(KeymapMode::CommandPalette, palette);
+
         keymap
+    }
+
+    /// `[[command]]` で定義された custom command の `key` を global keymap に登録する。
+    /// インデックスは `CustomCommandConfig` 配列の順序に対応し、`Action::RunCustomCommand(idx)` として保持される。
+    /// `key` 未指定 / parse 失敗 / index >= 256 のエントリは無視する。
+    pub fn register_custom_commands(mut self, commands: &[crate::config::CustomCommandConfig]) -> Self {
+        for (idx, cmd) in commands.iter().enumerate() {
+            if idx >= 256 {
+                break;
+            }
+            let Some(key_str) = cmd.key.as_deref() else {
+                continue;
+            };
+            let Ok(bind) = KeyBind::parse(key_str) else {
+                continue;
+            };
+            self.global.insert(bind, Action::RunCustomCommand(idx as u8));
+        }
+        self
     }
 
     /// Merge user overrides on top of defaults.
@@ -518,6 +554,7 @@ impl Keymap {
             ("create_card", KeymapMode::CreateCardGlobal),
             ("edit_card", KeymapMode::EditCardGlobal),
             ("bulk_select", KeymapMode::BulkSelect),
+            ("command_palette", KeymapMode::CommandPalette),
         ];
 
         for (config_key, mode) in mode_configs {
@@ -663,6 +700,9 @@ fn parse_action_name(name: &str) -> Option<Action> {
         "bulk_archive" => Some(Action::BulkArchive),
         "bulk_move_left" => Some(Action::BulkMoveLeft),
         "bulk_move_right" => Some(Action::BulkMoveRight),
+        "open_command_palette" => Some(Action::OpenCommandPalette),
+        // `run_custom_command` は index 付きなので config 文字列からの parse 対象外。
+        // 各 `[[command]]` の `key` が直接 keymap に bind される (`Keymap::register_custom_commands`)。
         _ => None,
     }
 }
@@ -721,6 +761,8 @@ pub fn action_name(action: Action) -> &'static str {
         Action::BulkArchive => "bulk_archive",
         Action::BulkMoveLeft => "bulk_move_left",
         Action::BulkMoveRight => "bulk_move_right",
+        Action::OpenCommandPalette => "open_command_palette",
+        Action::RunCustomCommand(_) => "run_custom_command",
     }
 }
 
@@ -1040,6 +1082,99 @@ mod tests {
         let bindings = keymap.bindings_for_action(KeymapMode::Board, Action::MoveDown);
         assert!(bindings.contains(&&KeyBind::char('j')));
         assert!(bindings.contains(&&KeyBind::key(KeyCode::Down)));
+    }
+
+    // ========== register_custom_commands tests ==========
+
+    #[test]
+    fn test_register_custom_commands_global_bind() {
+        let commands = vec![
+            crate::config::CustomCommandConfig {
+                name: "First".into(),
+                command: "echo a".into(),
+                key: Some("C-r".into()),
+                interactive: true,
+                description: None,
+            },
+            crate::config::CustomCommandConfig {
+                name: "Second".into(),
+                command: "echo b".into(),
+                key: None, // 未指定なので無視
+                interactive: true,
+                description: None,
+            },
+            crate::config::CustomCommandConfig {
+                name: "Third".into(),
+                command: "echo c".into(),
+                key: Some("C-t".into()),
+                interactive: true,
+                description: None,
+            },
+        ];
+        let keymap = Keymap::default_keymap().register_custom_commands(&commands);
+
+        // 0 番目: C-r が RunCustomCommand(0)
+        assert_eq!(
+            keymap.resolve(KeymapMode::Board, &make_key_event(KeyCode::Char('r'), KeyModifiers::CONTROL)),
+            Some(Action::RunCustomCommand(0))
+        );
+        // 1 番目: key 未指定なので bind されない
+        // 2 番目: C-t が RunCustomCommand(2)
+        assert_eq!(
+            keymap.resolve(KeymapMode::Board, &make_key_event(KeyCode::Char('t'), KeyModifiers::CONTROL)),
+            Some(Action::RunCustomCommand(2))
+        );
+    }
+
+    #[test]
+    fn test_register_custom_commands_works_across_modes() {
+        // global にバインドされるので、Board 以外でも resolve できることを確認
+        let commands = vec![crate::config::CustomCommandConfig {
+            name: "X".into(),
+            command: "echo".into(),
+            key: Some("C-r".into()),
+            interactive: true,
+            description: None,
+        }];
+        let keymap = Keymap::default_keymap().register_custom_commands(&commands);
+        assert_eq!(
+            keymap.resolve(KeymapMode::DetailContent, &make_key_event(KeyCode::Char('r'), KeyModifiers::CONTROL)),
+            Some(Action::RunCustomCommand(0))
+        );
+    }
+
+    #[test]
+    fn test_register_custom_commands_invalid_key_ignored() {
+        let commands = vec![crate::config::CustomCommandConfig {
+            name: "Bad".into(),
+            command: "echo".into(),
+            key: Some("totally-bogus".into()),
+            interactive: true,
+            description: None,
+        }];
+        let keymap = Keymap::default_keymap().register_custom_commands(&commands);
+        // 何も bind されていないので resolve に影響しないことを確認 (適当な key を投げて元の挙動)
+        assert_eq!(
+            keymap.resolve(KeymapMode::Board, &make_key_event(KeyCode::Char('j'), KeyModifiers::NONE)),
+            Some(Action::MoveDown)
+        );
+    }
+
+    #[test]
+    fn test_command_palette_resolves() {
+        let keymap = Keymap::default_keymap();
+        assert_eq!(
+            keymap.resolve(KeymapMode::Board, &make_key_event(KeyCode::Char(':'), KeyModifiers::NONE)),
+            Some(Action::OpenCommandPalette)
+        );
+        assert_eq!(
+            keymap.resolve(KeymapMode::DetailContent, &make_key_event(KeyCode::Char(':'), KeyModifiers::NONE)),
+            Some(Action::OpenCommandPalette)
+        );
+        assert_eq!(
+            keymap.resolve(KeymapMode::CommandPalette, &make_key_event(KeyCode::Enter, KeyModifiers::NONE)),
+            Some(Action::Select)
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,8 +110,11 @@ async fn run(terminal: &mut DefaultTerminal, github: GitHubClient, cli: Cli, cfg
     app.state.set_views(cfg.view);
     app.state.preferred_grouping_field_name = cfg.board.group_by.clone();
 
-    let keymap = keymap::Keymap::default_keymap().with_overrides(&cfg.keys);
+    let keymap = keymap::Keymap::default_keymap()
+        .with_overrides(&cfg.keys)
+        .register_custom_commands(&cfg.commands);
     app.state.set_keymap(keymap);
+    app.state.set_custom_commands(cfg.commands);
 
     // When project number is specified, load that project directly (skip project list)
     if let Some(number) = cli.number {
@@ -173,12 +176,52 @@ async fn run(terminal: &mut DefaultTerminal, github: GitHubClient, cli: Cli, cfg
             }
         }
 
+        // [[command]] でユーザ定義された interactive コマンドを実行
+        if let Some(pending) = app.pending_custom_command.take() {
+            events.pause();
+            disable_raw_mode()?;
+            crossterm::execute!(std::io::stdout(), DisableMouseCapture, LeaveAlternateScreen)?;
+
+            let status = run_custom_command(&pending.command_line);
+
+            enable_raw_mode()?;
+            crossterm::execute!(std::io::stdout(), EnterAlternateScreen, EnableMouseCapture)?;
+            terminal.clear()?;
+            events.resume();
+
+            match status {
+                Ok(status) if status.success() => {
+                    app.state.toast = Some(format!("✓ {}", pending.name));
+                }
+                Ok(status) => {
+                    app.state.toast = Some(format!(
+                        "✗ {} (exit {})",
+                        pending.name,
+                        status.code().unwrap_or(-1)
+                    ));
+                }
+                Err(e) => {
+                    app.state.toast = Some(format!("✗ {}: {e}", pending.name));
+                }
+            }
+        }
+
         if app.state.should_quit {
             break;
         }
     }
 
     Ok(())
+}
+
+fn run_custom_command(command_line: &str) -> std::io::Result<std::process::ExitStatus> {
+    std::process::Command::new("sh")
+        .arg("-c")
+        .arg(command_line)
+        .stdin(std::process::Stdio::inherit())
+        .stdout(std::process::Stdio::inherit())
+        .stderr(std::process::Stdio::inherit())
+        .status()
 }
 
 fn run_editor(content: &str) -> Result<String> {
@@ -342,6 +385,11 @@ fn render(frame: &mut Frame, app: &App) {
         Scene::BulkSelect => {
             render_board_with_tabs(frame, main_area, app);
             ui::statusline::render(frame, area, app);
+        }
+        Scene::CommandPalette => {
+            render_board_with_tabs(frame, main_area, app);
+            ui::statusline::render(frame, area, app);
+            ui::command_palette::render(frame, area, app);
         }
     }
 

--- a/src/model/state.rs
+++ b/src/model/state.rs
@@ -21,6 +21,7 @@ pub enum ViewMode {
     GroupBySelect,
     ReactionPicker,
     BulkSelect,
+    CommandPalette,
 }
 
 /// 現在表示中の「シーン」。Phase B リファクタで段階的にモード固有の state を
@@ -50,6 +51,7 @@ pub enum Scene {
     GroupBySelect(GroupBySelectState),
     ReactionPicker(ReactionPickerState),
     BulkSelect,
+    CommandPalette,
 }
 
 /// Board の表示レイアウト。Kanban (Board) / Table / Roadmap の 3 種類をサポート。

--- a/src/ui/command_palette.rs
+++ b/src/ui/command_palette.rs
@@ -1,0 +1,134 @@
+use ratatui::{
+    layout::{Constraint, Layout, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, BorderType, Borders, Clear, Padding, Paragraph},
+    Frame,
+};
+
+use crate::app::App;
+use crate::ui::layout::modal_area_pct;
+use crate::ui::theme::theme;
+
+pub fn render(frame: &mut Frame, area: Rect, app: &App) {
+    let commands = &app.state.custom_commands;
+    let cursor = app.state.command_palette_cursor;
+
+    let popup = modal_area_pct(60, 70, area);
+    frame.render_widget(Clear, popup);
+
+    let block = Block::default()
+        .title(" Custom Commands ")
+        .title_style(
+            Style::default()
+                .fg(theme().accent)
+                .add_modifier(Modifier::BOLD),
+        )
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(theme().accent))
+        .padding(Padding::horizontal(1));
+
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+
+    if inner.height < 2 || inner.width < 4 {
+        return;
+    }
+
+    if commands.is_empty() {
+        let msg = Paragraph::new(Line::from(Span::styled(
+            "No custom commands defined. Add [[command]] entries to config.toml.",
+            Style::default().fg(theme().text_muted),
+        )));
+        frame.render_widget(msg, inner);
+        return;
+    }
+
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    for (i, cmd) in commands.iter().enumerate() {
+        let is_selected = i == cursor;
+        let marker = if is_selected { "▶ " } else { "  " };
+        let name_style = if is_selected {
+            Style::default()
+                .fg(theme().accent)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(theme().text)
+        };
+        let key_style = Style::default().fg(theme().text_muted);
+        let desc_style = Style::default().fg(theme().text_dim);
+
+        let key_label = cmd
+            .key
+            .as_deref()
+            .map(|k| format!(" [{k}]"))
+            .unwrap_or_default();
+
+        let mut spans = vec![
+            Span::styled(marker.to_string(), name_style),
+            Span::styled(cmd.name.clone(), name_style),
+            Span::styled(key_label, key_style),
+        ];
+        if let Some(desc) = &cmd.description {
+            spans.push(Span::raw("  "));
+            spans.push(Span::styled(desc.clone(), desc_style));
+        }
+        lines.push(Line::from(spans));
+    }
+
+    let vert = Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).split(inner);
+    let total = lines.len();
+    let viewport = vert[0].height as usize;
+    let scroll = compute_scroll(cursor, viewport, total);
+    frame.render_widget(
+        Paragraph::new(lines).scroll((scroll as u16, 0)),
+        vert[0],
+    );
+
+    let hint_style = Style::default()
+        .fg(theme().text)
+        .add_modifier(Modifier::BOLD);
+    let desc_style = Style::default().fg(theme().text_muted);
+    let footer = Line::from(vec![
+        Span::styled("j/k", hint_style),
+        Span::styled(":nav  ", desc_style),
+        Span::styled("Enter", hint_style),
+        Span::styled(":run  ", desc_style),
+        Span::styled("Esc", hint_style),
+        Span::styled(":close", desc_style),
+    ]);
+    frame.render_widget(footer, vert[1]);
+}
+
+fn compute_scroll(cursor: usize, viewport: usize, total: usize) -> usize {
+    if viewport == 0 || total <= viewport {
+        return 0;
+    }
+    if cursor < viewport {
+        return 0;
+    }
+    let max_scroll = total - viewport;
+    (cursor + 1 - viewport).min(max_scroll)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::compute_scroll;
+
+    #[test]
+    fn scroll_zero_when_fits() {
+        assert_eq!(compute_scroll(0, 10, 5), 0);
+        assert_eq!(compute_scroll(4, 10, 5), 0);
+    }
+
+    #[test]
+    fn scroll_follows_cursor() {
+        // viewport 3, total 10
+        assert_eq!(compute_scroll(0, 3, 10), 0);
+        assert_eq!(compute_scroll(2, 3, 10), 0);
+        assert_eq!(compute_scroll(3, 3, 10), 1);
+        assert_eq!(compute_scroll(5, 3, 10), 3);
+        assert_eq!(compute_scroll(9, 3, 10), 7);
+    }
+}

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -105,6 +105,7 @@ pub fn render(frame: &mut Frame, area: Rect, keymap: &Keymap) {
         entry(Action::StartFilter, "help.entries.start_filter"),
         entry(Action::ClearFilter, "help.entries.clear_filter"),
         entry(Action::Refresh, "help.entries.refresh"),
+        entry(Action::OpenCommandPalette, "help.entries.open_command_palette"),
         entry(Action::ShowHelp, "help.entries.show_help"),
         entry(Action::Quit, "help.entries.quit"),
     ];

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,5 +1,6 @@
 pub mod board;
 pub mod card;
+pub mod command_palette;
 pub mod comment_list;
 pub mod confirm;
 pub mod detail;


### PR DESCRIPTION
## Summary

- `~/.config/gh-board/config.toml` の `[[command]]` でユーザ定義のシェルコマンドを宣言し、Board / Detail からカード文脈付きで実行できるようにする
- 発火経路は 2 通り: `key` バインドで直接 / `:` で開くパレットから選択
- `interactive = true` (default) は `$EDITOR` と同じく TUI を一時停止して `sh -c` を foreground 実行 (claude / vim 用)。`false` はバックグラウンド spawn

closes #88

## 使い方

\`\`\`toml
[[command]]
name = \"Resolve with Claude\"
command = \"git worktree add ../{repo}.resolve-{number} -b resolve-{number} && cd ../{repo}.resolve-{number} && claude 'https://github.com/{owner}/{repo}/issues/{number} を解決してください'\"
key = \"C-r\"
description = \"worktree を作って claude を起動する\"

[[command]]
name = \"Copy issue ref\"
command = \"printf '#%s' '{number}' | pbcopy\"
interactive = false
\`\`\`

利用できる placeholder: \`{number}\` \`{title}\` \`{url}\` \`{owner}\` \`{repo}\` \`{name_with_owner}\` \`{id}\` \`{content_id}\` \`{item_id}\` \`{body}\` \`{card_type}\` \`{project_number}\` \`{project_title}\` \`{project_url}\`。未対応キーは \`{...}\` のまま残す (将来拡張に安全)。

## 設計メモ

- Functional Core / Imperative Shell パターンに沿って実装
  - **AppState**: `custom_commands: Vec<CustomCommandConfig>` を保持。`Command::RunCustomCommand` を返すだけで副作用は持たない
  - **App**: \`Command::RunCustomCommand\` を受けて \`pending_custom_command\` を立てる (interactive) or \`tokio::spawn\` (background)
  - **main.rs**: \`pending_custom_command\` を見つけたら \`$EDITOR\` と同じ手順で TUI suspend → \`sh -c\` → resume → toast 表示
- placeholder 展開は \`src/app_state/custom_command.rs::expand_placeholders\`。card 未選択時はカード関連 placeholder を空文字に展開
- 各 \`[[command]]\` の \`key\` は \`Keymap::register_custom_commands\` で \`Action::RunCustomCommand(idx)\` として global keymap にバインド (Board / Detail どこでも発火)
- パレットは \`ViewMode::CommandPalette\` + \`Scene::CommandPalette\` + \`KeymapMode::CommandPalette\` を新設し、\`src/ui/command_palette.rs\` で描画

## Test plan

- [x] \`cargo test\` (499 件通過、16 件を本 PR で追加)
- [x] \`cargo clippy --all-targets -- -D warnings\` (warning 0)
- [ ] 実機での動作確認:
  - [ ] \`config.toml\` に \`[[command]]\` を 1 つ書いて \`key\` を押すと TUI が落ちてコマンドが foreground で動き、終了後にボードに戻る
  - [ ] \`:\` でパレットが開き、j/k で選択、Enter で実行、Esc で閉じる
  - [ ] Draft Issue 選択中に \`{number}\` 等を含むコマンドを実行しても panic せず、空文字で展開される
  - [ ] \`interactive = false\` のコマンドが画面を乱さずバックグラウンドで動く

🤖 Generated with [Claude Code](https://claude.com/claude-code)