### PR TITLE
feat(commands): カスタムコマンドに post_command と pause_after を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,7 +216,9 @@ assert_eq!(cmd, Command::MoveCard { ... });
 
 ### カスタムコマンド (`[[command]]`)
 - `~/.config/gh-board/config.toml` の `[[command]]` で定義した shell snippet を、選択中のカードを context にして実行する
-- 各 entry: `name` / `command` / `key`(任意) / `interactive`(default true) / `description`(任意)
+- 各 entry: `name` / `command` / `post_command`(任意) / `key`(任意) / `interactive`(default true) / `pause_after`(default false) / `description`(任意)
+- `post_command` は `command` が成功 (exit 0) した後に同じ placeholder context で展開して実行する後処理 (cleanup 用)。worktree 作成 → 作業 → 削除のようなライフサイクルに使う。interactive メインでは TUI を止めたまま続けて foreground 実行し、background メインでは `command && post_command` として連結して spawn する
+- `pause_after = true` の場合、interactive 実行 (command + post_command) 完了後に `main.rs::wait_for_key` で "Press any key" のキー入力を1つ待ってから TUI へ復帰する。`echo` 等の出力を確認したいコマンド向け。`crossterm::event::read()` で Key イベントを待つ間は `events.pause()` 済みなので競合しない。`interactive = false` (background) では無視
 - `command` 内の `{number}` `{title}` `{url}` `{owner}` `{repo}` `{name_with_owner}` `{id}` `{content_id}` `{item_id}` `{body}` `{card_type}` `{project_number}` `{project_title}` `{project_url}` が `src/app_state/custom_command.rs::expand_placeholders` で展開される。未対応 key は `{...}` のまま残る (将来拡張に安全)
 - 発火経路:
   - `key` が登録されたエントリは `Keymap::register_custom_commands` で `global` に bind され、Board / Detail から直接発動

--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Define shell snippets in `~/.config/gh-board/config.toml` and run them against t
 [[command]]
 name = "Resolve with Claude"
 command = "git worktree add ../{repo}.resolve-{number} -b resolve-{number} && cd ../{repo}.resolve-{number} && claude 'https://github.com/{owner}/{repo}/issues/{number} を解決してください'"
+post_command = "git worktree remove ../{repo}.resolve-{number} --force"
 key = "C-r"
 description = "Spawn a worktree and launch claude inside"
 
@@ -197,6 +198,11 @@ description = "Spawn a worktree and launch claude inside"
 name = "Copy issue ref"
 command = "printf '#%s' '{number}' | pbcopy"
 interactive = false
+
+[[command]]
+name = "Show gh status"
+command = "gh pr checks {number}"
+pause_after = true
 ```
 
 Available placeholders (resolved from the selected card / current project):
@@ -216,6 +222,8 @@ Available placeholders (resolved from the selected card / current project):
 Notes:
 - `command` is executed via `sh -c`, so you can chain with `&&`, `|`, etc.
 - `interactive = true` (default) suspends the TUI like `$EDITOR` does — required for tools that take over the terminal (e.g. `claude`, `vim`). `interactive = false` runs the command in the background and discards its output.
+- `post_command` (optional) runs **after** `command` succeeds (exit 0), expanded with the same placeholders. Handy for cleanup such as removing a worktree once you are done. With an interactive `command` it runs in the same suspended-TUI session; with a background `command` it is chained as `command && post_command`. If `command` fails, `post_command` is skipped so you can inspect the leftover state.
+- `pause_after = true` (default `false`, interactive only) waits for a key press after the command (and `post_command`) finishes before returning to the board, so you can read the output of commands that don't take over the terminal (e.g. `echo`, `gh pr checks`).
 - Placeholders for fields the card does not have (e.g. `{number}` on a draft issue) expand to an empty string. Unknown placeholders are left intact so you can compose your own templates safely.
 - Commands without a `key` are still reachable via the `:` palette.
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -676,18 +676,28 @@ impl App {
             Command::RunCustomCommand {
                 name,
                 command_line,
+                post_command_line,
                 interactive,
+                pause_after,
             } => {
                 if interactive {
                     self.pending_custom_command = Some(PendingCustomCommand {
                         name,
                         command_line,
+                        post_command_line,
+                        pause_after,
                     });
                 } else {
+                    // background 実行。post_command は `&&` で連結し、command が
+                    // 成功 (exit 0) したときのみ実行されるようにする。
+                    let line = match post_command_line {
+                        Some(post) => format!("{command_line} && {post}"),
+                        None => command_line,
+                    };
                     tokio::spawn(async move {
                         let _ = tokio::process::Command::new("sh")
                             .arg("-c")
-                            .arg(&command_line)
+                            .arg(&line)
                             .stdin(std::process::Stdio::null())
                             .stdout(std::process::Stdio::null())
                             .stderr(std::process::Stdio::null())
@@ -704,6 +714,10 @@ impl App {
 pub struct PendingCustomCommand {
     pub name: String,
     pub command_line: String,
+    /// `command_line` が成功した後に foreground 実行する後処理 (option)。
+    pub post_command_line: Option<String>,
+    /// 実行完了後にキー入力を待ってから TUI へ復帰するか。
+    pub pause_after: bool,
 }
 
 /// AppState 処理後に App が行うキャッシュ操作。`handle_event` で event を消費する前に

--- a/src/app_state/custom_command.rs
+++ b/src/app_state/custom_command.rs
@@ -136,10 +136,16 @@ impl AppState {
             .or_else(|| self.selected_card_ref());
         let project = self.current_project.as_ref();
         let command_line = expand_placeholders(&cfg.command, card, project);
+        let post_command_line = cfg
+            .post_command
+            .as_ref()
+            .map(|c| expand_placeholders(c, card, project));
         Command::RunCustomCommand {
             name: cfg.name.clone(),
             command_line,
+            post_command_line,
             interactive: cfg.interactive,
+            pause_after: cfg.pause_after,
         }
     }
 

--- a/src/app_state/mod.rs
+++ b/src/app_state/mod.rs
@@ -8373,8 +8373,10 @@ mod tests {
         crate::config::CustomCommandConfig {
             name: name.into(),
             command: command.into(),
+            post_command: None,
             key: key.map(String::from),
             interactive: true,
+            pause_after: false,
             description: None,
         }
     }
@@ -8415,7 +8417,9 @@ mod tests {
             Command::RunCustomCommand {
                 name: "Resolve".into(),
                 command_line: "echo 42 widget".into(),
+                post_command_line: None,
                 interactive: true,
+                pause_after: false,
             }
         );
     }
@@ -8465,7 +8469,9 @@ mod tests {
             Command::RunCustomCommand {
                 name: "Second".into(),
                 command_line: "echo second-42".into(),
+                post_command_line: None,
                 interactive: true,
+                pause_after: false,
             }
         );
         // 元の Board モードに戻っている
@@ -8491,6 +8497,38 @@ mod tests {
         // パレットは開かない
         assert_eq!(state.mode, ViewMode::Board);
         assert!(state.toast.is_some());
+    }
+
+    #[test]
+    fn run_custom_command_expands_post_command() {
+        let commands = vec![crate::config::CustomCommandConfig {
+            name: "Resolve".into(),
+            command: "claude '{url}'".into(),
+            post_command: Some("git worktree remove ../resolve-{number} --force".into()),
+            key: Some("C-r".into()),
+            interactive: true,
+            pause_after: false,
+            description: None,
+        }];
+        let mut state = make_state_with_issue_card_and_commands(commands);
+
+        let cmd = state.handle_event(AppEvent::Key(key_with_mod(
+            KeyCode::Char('r'),
+            KeyModifiers::CONTROL,
+        )));
+
+        assert_eq!(
+            cmd,
+            Command::RunCustomCommand {
+                name: "Resolve".into(),
+                command_line: "claude 'https://github.com/acme/widget/issues/42'".into(),
+                post_command_line: Some(
+                    "git worktree remove ../resolve-42 --force".into()
+                ),
+                interactive: true,
+                pause_after: false,
+            }
+        );
     }
 
     #[test]
@@ -8525,7 +8563,9 @@ mod tests {
             Command::RunCustomCommand {
                 name: "X".into(),
                 command_line: "echo 100".into(),
+                post_command_line: None,
                 interactive: true,
+                pause_after: false,
             }
         );
     }

--- a/src/command.rs
+++ b/src/command.rs
@@ -149,10 +149,14 @@ pub enum Command {
     /// ユーザ定義のシェルコマンドを実行する。
     /// `command_line` は placeholder 展開済みの文字列で、`sh -c <command_line>` として渡される。
     /// `interactive = true` の場合は TUI を一時停止して foreground 実行する。
+    /// `post_command_line` があれば `command_line` の成功後に同じモードで実行する (cleanup 用)。
+    /// `pause_after = true` の場合、interactive 実行の完了後にキー入力を待ってから TUI へ復帰する。
     RunCustomCommand {
         name: String,
         command_line: String,
+        post_command_line: Option<String>,
         interactive: bool,
+        pause_after: bool,
     },
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -45,18 +45,29 @@ fn default_true() -> bool {
 /// ユーザ定義のシェルコマンド。
 /// `command` は `sh -c <command>` で実行され、現在選択中のカードから次の placeholder が展開される:
 /// `{number}` `{title}` `{url}` `{owner}` `{repo}` `{name_with_owner}` `{id}` `{item_id}` `{body}` `{project_number}` `{project_title}` `{project_url}`.
+/// `post_command` を指定すると、`command` が成功した後に同じ context で展開して実行する。
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 pub struct CustomCommandConfig {
     /// パレットや status line に表示する名前。
     pub name: String,
     /// `sh -c` に渡すコマンド文字列。placeholder を含められる。
     pub command: String,
+    /// `command` が成功 (exit 0) した後に実行する後処理コマンド (option)。
+    /// placeholder は `command` と同じ context で展開される。
+    /// worktree の作成 → 作業 → 削除のような cleanup 用途を想定。
+    #[serde(default)]
+    pub post_command: Option<String>,
     /// 任意のキーバインド (例: "C-r")。指定時は global keymap に登録され、Board/Detail から即時起動できる。
     #[serde(default)]
     pub key: Option<String>,
     /// true の場合は TUI を一時停止して foreground 実行する ($EDITOR と同様)。default: true。
     #[serde(default = "default_true")]
     pub interactive: bool,
+    /// true の場合、interactive 実行の完了後に "Press any key" でキー入力を待ってから
+    /// TUI に復帰する。echo や cleanup など出力を確認したいコマンド向け。default: false。
+    /// `interactive = false` (background) では無視される。
+    #[serde(default)]
+    pub pause_after: bool,
     /// パレットや status line に表示する説明 (option)。
     #[serde(default)]
     pub description: Option<String>,
@@ -600,6 +611,56 @@ description = "Spawn claude inside a new worktree"
         assert_eq!(
             config.commands[0].description.as_deref(),
             Some("Spawn claude inside a new worktree")
+        );
+    }
+
+    #[test]
+    fn test_parse_command_post_command_default_none() {
+        let toml = r#"
+[[command]]
+name = "Print number"
+command = "echo {number}"
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert_eq!(config.commands[0].post_command, None);
+    }
+
+    #[test]
+    fn test_parse_command_pause_after_default_false() {
+        let toml = r#"
+[[command]]
+name = "Print number"
+command = "echo {number}"
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert!(!config.commands[0].pause_after);
+    }
+
+    #[test]
+    fn test_parse_command_with_pause_after() {
+        let toml = r#"
+[[command]]
+name = "Print number"
+command = "echo {number}"
+pause_after = true
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert!(config.commands[0].pause_after);
+    }
+
+    #[test]
+    fn test_parse_command_with_post_command() {
+        let toml = r#"
+[[command]]
+name = "Resolve with Claude"
+command = "git worktree add ../resolve-{number} -b resolve-{number} && cd ../resolve-{number} && claude '{url}'"
+post_command = "git worktree remove ../resolve-{number} --force"
+key = "C-r"
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert_eq!(
+            config.commands[0].post_command.as_deref(),
+            Some("git worktree remove ../resolve-{number} --force")
         );
     }
 

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -1092,22 +1092,28 @@ mod tests {
             crate::config::CustomCommandConfig {
                 name: "First".into(),
                 command: "echo a".into(),
+                post_command: None,
                 key: Some("C-r".into()),
                 interactive: true,
+                pause_after: false,
                 description: None,
             },
             crate::config::CustomCommandConfig {
                 name: "Second".into(),
                 command: "echo b".into(),
+                post_command: None,
                 key: None, // 未指定なので無視
                 interactive: true,
+                pause_after: false,
                 description: None,
             },
             crate::config::CustomCommandConfig {
                 name: "Third".into(),
                 command: "echo c".into(),
+                post_command: None,
                 key: Some("C-t".into()),
                 interactive: true,
+                pause_after: false,
                 description: None,
             },
         ];
@@ -1132,8 +1138,10 @@ mod tests {
         let commands = vec![crate::config::CustomCommandConfig {
             name: "X".into(),
             command: "echo".into(),
+            post_command: None,
             key: Some("C-r".into()),
             interactive: true,
+            pause_after: false,
             description: None,
         }];
         let keymap = Keymap::default_keymap().register_custom_commands(&commands);
@@ -1148,8 +1156,10 @@ mod tests {
         let commands = vec![crate::config::CustomCommandConfig {
             name: "Bad".into(),
             command: "echo".into(),
+            post_command: None,
             key: Some("totally-bogus".into()),
             interactive: true,
+            pause_after: false,
             description: None,
         }];
         let keymap = Keymap::default_keymap().register_custom_commands(&commands);

--- a/src/main.rs
+++ b/src/main.rs
@@ -184,26 +184,24 @@ async fn run(terminal: &mut DefaultTerminal, github: GitHubClient, cli: Cli, cfg
 
             let status = run_custom_command(&pending.command_line);
 
+            // command が成功した場合のみ post_command を続けて foreground 実行する (cleanup)。
+            let post_status = match (&status, &pending.post_command_line) {
+                (Ok(s), Some(post)) if s.success() => Some(run_custom_command(post)),
+                _ => None,
+            };
+
+            // pause_after が指定されていれば、出力を残したままキー入力を待つ。
+            // この時点では raw mode 無効 + 通常画面なのでコマンド出力が見えている。
+            if pending.pause_after {
+                wait_for_key()?;
+            }
+
             enable_raw_mode()?;
             crossterm::execute!(std::io::stdout(), EnterAlternateScreen, EnableMouseCapture)?;
             terminal.clear()?;
             events.resume();
 
-            match status {
-                Ok(status) if status.success() => {
-                    app.state.toast = Some(format!("✓ {}", pending.name));
-                }
-                Ok(status) => {
-                    app.state.toast = Some(format!(
-                        "✗ {} (exit {})",
-                        pending.name,
-                        status.code().unwrap_or(-1)
-                    ));
-                }
-                Err(e) => {
-                    app.state.toast = Some(format!("✗ {}: {e}", pending.name));
-                }
-            }
+            app.state.toast = Some(custom_command_toast(&pending.name, status, post_status));
         }
 
         if app.state.should_quit {
@@ -211,6 +209,50 @@ async fn run(terminal: &mut DefaultTerminal, github: GitHubClient, cli: Cli, cfg
         }
     }
 
+    Ok(())
+}
+
+/// custom command (+ post_command) の実行結果から status line に出す toast を組み立てる。
+/// post_command が失敗した場合は command 成功でも警告を出す。
+fn custom_command_toast(
+    name: &str,
+    status: std::io::Result<std::process::ExitStatus>,
+    post_status: Option<std::io::Result<std::process::ExitStatus>>,
+) -> String {
+    match status {
+        Ok(s) if s.success() => match post_status {
+            Some(Ok(p)) if p.success() => format!("✓ {name}"),
+            Some(Ok(p)) => format!("✗ {name}: post-command failed (exit {})", p.code().unwrap_or(-1)),
+            Some(Err(e)) => format!("✗ {name}: post-command error: {e}"),
+            None => format!("✓ {name}"),
+        },
+        Ok(s) => format!("✗ {name} (exit {})", s.code().unwrap_or(-1)),
+        Err(e) => format!("✗ {name}: {e}"),
+    }
+}
+
+/// custom command の出力を残したまま、ユーザのキー入力を1つ待つ。
+/// 呼び出し時点では raw mode は無効・通常画面の想定。一時的に raw mode を有効化して
+/// 1 キー押下まで待ち、元に戻す (呼び出し元が直後に enable_raw_mode を行う)。
+fn wait_for_key() -> std::io::Result<()> {
+    use std::io::Write;
+
+    print!("\r\n\x1b[1;36m[gh-board]\x1b[0m Press any key to return to the board...");
+    std::io::stdout().flush()?;
+
+    enable_raw_mode()?;
+    // Key 押下イベントが来るまで待つ (Resize/Mouse 等は無視)。
+    loop {
+        match crossterm::event::read() {
+            Ok(crossterm::event::Event::Key(_)) => break,
+            Ok(_) => continue,
+            Err(e) => {
+                let _ = disable_raw_mode();
+                return Err(e);
+            }
+        }
+    }
+    disable_raw_mode()?;
     Ok(())
 }
 


### PR DESCRIPTION
## 概要

`[[command]]` (カスタムコマンド) にライフサイクル制御のための2フィールドを追加しました。きっかけは「worktree を作成して作業し、終了したら作られた worktree を削除する」ような post-command 的な使い方をしたいという要望です。

## 追加フィールド

### `post_command` (任意)
`command` が成功 (exit 0) した後に、同じ placeholder context で展開して実行する後処理コマンドです。

```toml
[[command]]
name = "Resolve with Claude"
command = "git worktree add ../resolve-{number} -b resolve-{number} && cd ../resolve-{number} && claude '{url}'"
post_command = "git worktree remove ../resolve-{number} --force"
key = "C-r"
```

- **実行条件**: `command` が exit 0 のときのみ。失敗時はスキップして leftover を残し調査できる
- **実行モード**:
  - interactive メイン → TUI を止めたまま続けて foreground 実行
  - background メイン → `command && post_command` として連結し spawn

### `pause_after` (default `false`, interactive のみ)
`command` (+ `post_command`) 完了後に `Press any key to return to the board...` を表示し、キー入力を1つ待ってから TUI へ復帰します。`echo` や `gh pr checks` のように出力を残すコマンドの結果を確認したいケース向けです。`claude` / `vim` など全画面対話ツールには不要なのでデフォルト無効としています。

## 実装

- `src/config.rs` — `CustomCommandConfig` に `post_command` / `pause_after`
- `src/command.rs` — `RunCustomCommand` に `post_command_line` / `pause_after`
- `src/app_state/custom_command.rs` — `run_custom_command` で post を展開して伝搬
- `src/app.rs` — `PendingCustomCommand` に伝搬、background は `&&` 連結
- `src/main.rs` — foreground で成功時に post 実行、`pause_after` なら `wait_for_key()` でキー待ち、toast を `custom_command_toast` に集約
- `CLAUDE.md` / `README.md` 更新

## テスト

- `cargo test` 504件通過 (config パーステスト4件 + `run_custom_command_expands_post_command` 追加)
- `cargo clippy -- -D warnings` クリーン

Functional Core (展開・Command 生成) はテストで担保。foreground 実行とキー待ちは Imperative Shell (main.rs) のため手動確認推奨。